### PR TITLE
Align GroX 0.7.1 version metadata

### DIFF
--- a/src/grox/__init__.py
+++ b/src/grox/__init__.py
@@ -1,3 +1,3 @@
-__version__='0.7.0'
+__version__='0.7.1'
 from .pilot import PilotGorXu
 __all__=['PilotGorXu']

--- a/tests/contracts/test_version_consistency.py
+++ b/tests/contracts/test_version_consistency.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+import tomllib
+
+import grox
+
+
+def test_source_version_matches_package_metadata() -> None:
+    root = Path(__file__).resolve().parents[2]
+    project = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
+    assert grox.__version__ == project["project"]["version"]

--- a/tests/contracts/test_version_consistency.py
+++ b/tests/contracts/test_version_consistency.py
@@ -1,10 +1,16 @@
 from pathlib import Path
 import tomllib
+import unittest
 
 import grox
 
 
-def test_source_version_matches_package_metadata() -> None:
-    root = Path(__file__).resolve().parents[2]
-    project = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
-    assert grox.__version__ == project["project"]["version"]
+class VersionConsistencyTest(unittest.TestCase):
+    def test_source_version_matches_package_metadata(self) -> None:
+        root = Path(__file__).resolve().parents[2]
+        project = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
+        self.assertEqual(grox.__version__, project["project"]["version"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose
Close a post-merge stewardship defect discovered during recalibration after PR #14.

`pyproject.toml` and current documentation identify the source package as `0.7.1`, while `src/grox/__init__.py` still reported `__version__='0.7.0'`.

## Changes
- align `grox.__version__` to `0.7.1`;
- add `tests/contracts/test_version_consistency.py` so source version and `pyproject.toml` package metadata cannot drift silently again;
- implement the guard as `unittest.TestCase` so both pytest and `unittest discover` enforce the invariant.

## Final exact-head verification
Candidate head: `1573c891fc92c18673511e90c7b638f401b04eb1`

GroX CI run `31935094490`: **SUCCESS**

- Regression / Python 3.11: PASS
- Regression / Python 3.12: PASS
- Wheel bootstrap portability: PASS
- Python 3.12 pytest: **129 passed, 2 skipped**
- Python 3.12 unittest: **131 OK, 2 skipped**
- version consistency guard: PASS in both suites
- compile/diff hygiene: PASS

## Boundaries
- no Commander authority change;
- no GorXu orchestration change;
- no Crew or Division change;
- no routing, persistence, capability, or Tool Gateway change;
- Apex qualification semantics unchanged.

## Merge discipline
Use an exact-head guarded squash merge after separate Commander authorization.

Expected head SHA: `1573c891fc92c18673511e90c7b638f401b04eb1`.