### PR TITLE
Upgrade pinned GitHub Actions to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,9 @@ jobs:
         python-version: ['3.11', '3.12', '3.13', '3.14']
     steps:
       - name: Checkout
-        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install test runtime
@@ -54,9 +54,9 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.12'
       - name: Build non-editable wheel


### PR DESCRIPTION
## Purpose
Consolidate the two Dependabot proposals generated by Operational Audit 001 into one exact-head, fully pinned GitHub Actions maintenance update.

## Changes
- `actions/checkout` -> `3d3c42e5aac5ba805825da76410c181273ba90b1` (`v7.0.1`)
- `actions/setup-python` -> `5fda3b95a4ea91299a34e894583c3862153e4b97` (`v7.0.0`)

Both remain pinned to immutable full commit SHAs, preserving the Audit 001 supply-chain invariant.

## Research basis
- upstream `setup-python` documents v7 as an ESM/internal dependency migration with no action input/output/behavior changes for normal usage;
- upstream `checkout` v7.0.1 includes safer PR checkout handling, escaping fixes, and dependency updates;
- GroX uses ordinary `pull_request`/`push` checkout and explicit `python-version`, so no removed or changed input is used.

## Completion gate
All five canonical GroX CI jobs must pass on this exact candidate before merge: Python 3.11, 3.12, 3.13, 3.14, and Wheel bootstrap portability. No runtime, Crew, authority, routing, persistence, package, or capability changes.