### PR TITLE
Complete Stage 0 external capability intake convention

### DIFF
--- a/docs/history/ships-log/0040-external-capability-intake-formalized.md
+++ b/docs/history/ships-log/0040-external-capability-intake-formalized.md
@@ -1,0 +1,50 @@
+# Ship's Log 0040 — External Capability Intake Formalized
+
+**Date:** 2026-08-16
+
+**Program:** Post-Apex Operational Evolution Program 001
+
+**Stage:** 0 — External capability intake convention
+
+**Issue:** #29
+
+## Commander decision
+
+The Commander approved all actionable recommendations from the ClaudX comparative review and authorized execution in the dependency order recorded by Post-Apex Operational Evolution Program 001.
+
+Stage 0 required GroX to formalize how external repositories, agents, frameworks, protocols, skills, research, and architectural patterns enter evidence-driven evolution without becoming authority or creating duplicate architecture.
+
+## Canonical result
+
+`docs/stewardship/EXTERNAL_CAPABILITY_INTAKE.md` now defines the required intake posture:
+
+- `ADOPT`
+- `ADAPT`
+- `HARVEST`
+- `REJECT`
+
+The convention requires explicit checks for existing GroX coverage, novelty provenance, useful evidence, required stripping/adaptation, duplication risk, authority/privacy/portability risk, and the evidence threshold for any later implementation or qualification.
+
+It distinguishes external source facts and external evidence from GroX inference and GroX-native evidence. External claims therefore cannot silently become GroX qualification evidence.
+
+The convention is deliberately lightweight. It creates no new command layer, Crew class, approval body, runtime service, external dependency, or duplicate decisions ledger. Records remain in the existing Mission, issue, research, architecture, or stewardship surfaces appropriate to the work.
+
+## Exercise
+
+The convention was exercised against the pinned ClaudX review source:
+
+`vessaxor-spec/ClaudX@c82162b525ee183757e76300cc4a53f5643884f1`
+
+The exercise demonstrates per-seam classification rather than repository-wide adoption. Useful independent ideas were adapted or harvested, while GroX-derived concepts, duplicate truth stores, host-specific architecture, sleeping retired identities, unsupported synthetic proof, and authority-incompatible conclusions were rejected.
+
+## Authority result
+
+No Commander, GorXu, Crew, Tool Gateway, verifier, persistence, routing, or mutation authority changed.
+
+An intake decision remains advisory/planning evidence. Any implementation after `ADOPT`, `ADAPT`, or `HARVEST` still requires the ordinary GroX Mission, authority, verification, protected PR/CI, and canonical-source path.
+
+## Program transition
+
+Stage 0 exit condition is satisfied.
+
+The next authorized workstream is **Stage 1 / issue #25: prove critical GroX health and governance detectors by mutation**.

--- a/docs/stewardship/EXTERNAL_CAPABILITY_INTAKE.md
+++ b/docs/stewardship/EXTERNAL_CAPABILITY_INTAKE.md
@@ -129,13 +129,14 @@ The ClaudX review demonstrates that intake decisions are made per candidate seam
 | Health/governance detector mutation proving | HARVEST | Retain the test discipline only; apply it to GroX critical invariants under #25. |
 | Tiered fast/targeted/full reconstitution | ADAPT | Useful efficiency pattern, but GroX's stronger recovery gates remain authoritative; implement under #27. |
 | Long-horizon operational drift detection | ADAPT | Build on GroX A6 trajectories and non-self-activation rather than ClaudX's score implementation; track under #28. |
-| Hot/warm/cold context management | HARVEST | Test the principle with GroX-native evidence under #30; ClaudX's synthetic savings figure is not accepted as proof. |
-| Mission-to-source provenance | HARVEST / RESEARCH | Retain the traceability question only; threat-model GroX privacy and squash-merge behavior under #31 before implementation. |
-| GroX-derived command spine, Crew model, memory planes, durable operations, Mission Graph, A6 trajectory concepts | REJECT AS EXTERNAL NOVELTY | These originated from or are already native to GroX; re-import would be circular duplication. |
+| Hot/warm/cold context management | HARVEST | Test the principle with GroX-native evidence under #30; the external synthetic savings result is not accepted as proof. |
+| Mission-to-source provenance | HARVEST | Retain the traceability question only; next action is research under #31 before any implementation decision. |
+| GroX-derived command spine, Crew model, memory planes, durable operations, Mission Graph, A6 trajectory concepts | REJECT | These originated from or are already native to GroX; re-import would be circular duplication. |
 | Separate decisions ledger | REJECT | GroX already has canonical Mission/evidence/stewardship records; another ledger would duplicate truth. |
 | Host-specific `launchd` heartbeat implementation | REJECT | Host-specific architecture conflicts with Vessel portability. The abstract unattended-health idea may inform #26 without importing the implementation. |
 | Sleeping retired Crew identities | REJECT | Conflicts with GroX's canonical purge rule. |
-| Remove `orchestration-evaluation-analyst` because ClaudX removed a similar role | REJECT AS BASIS | GroX role decisions must use actual GroX authority and capability evidence. |
+| ClaudX synthetic 57.4% token-savings claim as GroX proof | REJECT | External synthetic measurement is not GroX qualification evidence; #30 must establish GroX evidence independently. |
+| Remove `orchestration-evaluation-analyst` because ClaudX removed a similar role | REJECT | GroX role decisions must use actual GroX authority and capability evidence. |
 
 ## Completion criterion
 

--- a/docs/stewardship/EXTERNAL_CAPABILITY_INTAKE.md
+++ b/docs/stewardship/EXTERNAL_CAPABILITY_INTAKE.md
@@ -1,0 +1,142 @@
+# GroX External Capability Intake
+
+## Purpose
+
+GroX may inspect external repositories, agents, frameworks, protocols, skills, research, and architectural patterns for useful ideas. External material is evidence and input, not authority.
+
+Before any material implementation derived from an external candidate, GorXu records one of four postures:
+
+- **ADOPT** — use essentially as-is only when the behavior, maintenance burden, authority model, security boundary, portability, and canonical placement already fit GroX.
+- **ADAPT** — retain the useful pattern but redesign it into GroX-native architecture and constraints.
+- **HARVEST** — extract only a specific principle, seam, test discipline, algorithm, or interface idea; do not import the surrounding system.
+- **REJECT** — do not incorporate the candidate. Preserve enough rationale to prevent repetitive reevaluation when the relevant evidence has not changed.
+
+This is a review convention, not a command layer, Crew class, approval body, runtime service, or separate decision ledger.
+
+## Authority boundary
+
+External intelligence never inherits GroX authority.
+
+A posture decision:
+
+- does not grant Mission authority;
+- does not authorize Repair or execution;
+- does not activate an A6 proposal;
+- does not create a new Crew identity;
+- does not make an external dependency canonical;
+- does not replace Commander approval, Mission Orders, Tool Gateway policy, verification, or protected repository controls.
+
+Implementation after an ADOPT, ADAPT, or HARVEST decision still travels through the ordinary GroX path: Commander intent -> GorXu -> bounded Mission/Orders -> implementation -> verification -> protected PR/CI -> canonical source.
+
+## Required review questions
+
+For every material external candidate, answer the smallest set of questions sufficient to make the decision:
+
+1. **Problem** — What concrete problem does the candidate solve?
+2. **Existing coverage** — Does GroX already solve this problem? If yes, identify the existing source, service, decision, or qualification evidence.
+3. **Novelty provenance** — Is the apparent novelty actually derived from GroX or another source already reviewed?
+4. **Useful evidence** — What specific behavior, measured result, failure lesson, interface, algorithm, or test discipline is worth retaining?
+5. **Required stripping** — What must be removed or redesigned to preserve GroX identity, Commander/GorXu authority, privacy, security, portability, and canonical structure?
+6. **Duplication risk** — Would incorporation create a duplicate truth store, Crew function, command path, policy engine, memory plane, telemetry system, or runtime dependency?
+7. **Evidence threshold** — What evidence is still required before implementation or qualification?
+8. **Decision** — ADOPT, ADAPT, HARVEST, or REJECT, with a concise rationale.
+9. **Next action** — research, bounded design, implementation Mission, experiment, or no action.
+
+## Decision rules
+
+### ADOPT
+
+Use only when all of the following are true:
+
+- behavior already fits GroX's command and authority model;
+- no duplicate source of truth or command path is introduced;
+- dependency and maintenance ownership are acceptable;
+- security and privacy boundaries are understood;
+- portability is acceptable;
+- current evidence supports the claimed benefit;
+- GroX can explain, test, maintain, and remove the adopted behavior.
+
+ADOPT should be uncommon for architecture-level material.
+
+### ADAPT
+
+Use when the underlying pattern is valuable but its native implementation, terminology, host assumptions, authority model, persistence model, or dependencies do not fit GroX.
+
+The adapted result must be GroX-native. The external source must not become an architectural authority merely because it inspired the design.
+
+### HARVEST
+
+Use when only a bounded idea is valuable. Typical examples include:
+
+- a testing discipline;
+- a failure mode or postmortem lesson;
+- an algorithmic seam;
+- an interface shape;
+- a measurement method;
+- an isolation or recovery technique.
+
+Harvesting intentionally leaves the surrounding external architecture behind.
+
+### REJECT
+
+Use when the candidate is redundant, circular, unsafe, unmaintainable, incompatible, insufficiently evidenced, or would add unjustified complexity.
+
+A rejection may be revisited only when material evidence or GroX requirements change.
+
+## Evidence quality
+
+Claims from an external project are not automatically GroX evidence.
+
+Distinguish:
+
+- **source fact** — what the external source actually implements or claims;
+- **external evidence** — tests, measurements, incidents, or operational history produced by that source;
+- **GroX inference** — what GorXu concludes may be relevant to the Vessel;
+- **GroX evidence** — results reproduced or measured under GroX's own architecture, Missions, tests, or qualified environments.
+
+Synthetic benchmarks, self-reported percentages, marketing claims, and unverified architectural assertions cannot become GroX qualification evidence merely by citation.
+
+## Minimal review record
+
+A material external review should preserve this compact record in the relevant Mission, issue, research note, architecture decision, or stewardship document. Do not create a parallel ledger solely for intake decisions.
+
+```text
+Candidate:
+Pinned source/version/commit:
+Problem addressed:
+Existing GroX coverage:
+Novelty provenance:
+Useful evidence/seams:
+Required stripping/adaptation:
+Duplication/authority/privacy risks:
+Evidence still required:
+Decision: ADOPT | ADAPT | HARVEST | REJECT
+Rationale:
+Next action:
+```
+
+If several independent seams from one source receive different postures, record them separately rather than forcing one project-wide classification.
+
+## Worked application — ClaudX comparative review
+
+**Pinned source:** `vessaxor-spec/ClaudX@c82162b525ee183757e76300cc4a53f5643884f1`
+
+The ClaudX review demonstrates that intake decisions are made per candidate seam, not per repository.
+
+| Candidate seam | Decision | Rationale / next action |
+|---|---|---|
+| Unified Vessel health surface | ADAPT | Useful diagnostic pattern; rebuild from GroX's authoritative services under #26 rather than copy ClaudX implementation. |
+| Health/governance detector mutation proving | HARVEST | Retain the test discipline only; apply it to GroX critical invariants under #25. |
+| Tiered fast/targeted/full reconstitution | ADAPT | Useful efficiency pattern, but GroX's stronger recovery gates remain authoritative; implement under #27. |
+| Long-horizon operational drift detection | ADAPT | Build on GroX A6 trajectories and non-self-activation rather than ClaudX's score implementation; track under #28. |
+| Hot/warm/cold context management | HARVEST | Test the principle with GroX-native evidence under #30; ClaudX's synthetic savings figure is not accepted as proof. |
+| Mission-to-source provenance | HARVEST / RESEARCH | Retain the traceability question only; threat-model GroX privacy and squash-merge behavior under #31 before implementation. |
+| GroX-derived command spine, Crew model, memory planes, durable operations, Mission Graph, A6 trajectory concepts | REJECT AS EXTERNAL NOVELTY | These originated from or are already native to GroX; re-import would be circular duplication. |
+| Separate decisions ledger | REJECT | GroX already has canonical Mission/evidence/stewardship records; another ledger would duplicate truth. |
+| Host-specific `launchd` heartbeat implementation | REJECT | Host-specific architecture conflicts with Vessel portability. The abstract unattended-health idea may inform #26 without importing the implementation. |
+| Sleeping retired Crew identities | REJECT | Conflicts with GroX's canonical purge rule. |
+| Remove `orchestration-evaluation-analyst` because ClaudX removed a similar role | REJECT AS BASIS | GroX role decisions must use actual GroX authority and capability evidence. |
+
+## Completion criterion
+
+This convention is successful when it prevents circular or duplicative adoption while allowing useful external evidence to enter GroX through bounded, attributable, GroX-native evolution.

--- a/docs/stewardship/POST_APEX_EVOLUTION_PROGRAM_001.md
+++ b/docs/stewardship/POST_APEX_EVOLUTION_PROGRAM_001.md
@@ -1,6 +1,6 @@
 # Post-Apex Operational Evolution Program 001
 
-**Status:** APPROVED FOR EXECUTION PLANNING
+**Status:** IN EXECUTION — STAGE 0 COMPLETE; STAGE 1 NEXT
 
 **Planning baseline:** `main@c93015278daf022b1c3d85fc8fb90a6fa52d8160`
 
@@ -48,15 +48,25 @@ The approved ClaudX review produced the following GroX decisions:
 
 The work is deliberately staged so later capabilities depend on trustworthy evidence rather than being built simultaneously.
 
-### Stage 0 - External capability intake convention
+### Stage 0 - External capability intake convention — COMPLETE
 
 **Issue:** #29
 
-Formalize the adopt/adapt/harvest/reject decision posture as a lightweight GroX review convention. This is process clarification only. It must not create a new command layer, mandatory agent, external dependency, or duplicate decision store.
+The lightweight GroX review convention is now defined in `docs/stewardship/EXTERNAL_CAPABILITY_INTAKE.md`.
 
-**Exit condition:** one canonical convention/template exists and the ClaudX review can be represented through it without architectural duplication.
+It establishes:
 
-### Stage 1 - Prove the detectors
+- per-candidate `ADOPT | ADAPT | HARVEST | REJECT` classification before material implementation from external sources;
+- explicit checks for existing coverage, novelty provenance, duplication, authority/privacy/portability risk, and evidence thresholds;
+- separation of external source facts, external evidence, GroX inference, and GroX-native evidence;
+- a compact review record that lives in existing Mission, issue, research, architecture, or stewardship records rather than a new decisions ledger;
+- explicit preservation of the normal Commander -> GorXu -> Mission/Order -> verification -> protected source path after any intake decision.
+
+The convention is exercised against the pinned ClaudX review, including different decisions for independent seams from the same repository and explicit rejection of circular GroX-derived material.
+
+**Exit condition:** PASSED. One canonical convention/template exists and the ClaudX review is represented through it without architectural duplication.
+
+### Stage 1 - Prove the detectors — NEXT
 
 **Issue:** #25
 

--- a/docs/stewardship/POST_APEX_EVOLUTION_PROGRAM_001.md
+++ b/docs/stewardship/POST_APEX_EVOLUTION_PROGRAM_001.md
@@ -26,7 +26,7 @@ The objective is to improve how the qualified Vessel determines its own conditio
 
 ## Source-review classification
 
-The approved ClaudX review produced the following GroX decisions:
+The approved ClaudX review produced the following GroX decisions. The posture column uses only the four canonical intake postures; research and testing are next actions, not additional postures.
 
 | Candidate | Posture | GroX action |
 |---|---|---|
@@ -35,14 +35,14 @@ The approved ClaudX review produced the following GroX decisions:
 | Tiered fast/targeted/full reconstitution | ADAPT | Optimize evidence loading without weakening existing recovery gates. |
 | Long-horizon operational drift detection | ADAPT | Extend A6 using real Mission trajectories and protected baselines. |
 | Adopt/adapt/harvest/reject intake discipline | HARVEST | Formalize a lightweight external-capability review convention. |
-| Hot/warm/cold context management | HARVEST / TEST | Run GroX-native controlled experiments before any runtime adoption. |
-| Mission-to-source provenance | RESEARCH | Threat-model and design before deciding whether to implement. |
-| ClaudX's GroX-derived command spine, Crew, memory, durable ops, Mission Graph, A6 concepts | REJECT AS EXTERNAL NOVELTY | Already native GroX capability; do not re-import or duplicate. |
+| Hot/warm/cold context management | HARVEST | Run GroX-native controlled experiments before any runtime adoption. |
+| Mission-to-source provenance | HARVEST | Retain the traceability question; research and threat-model it before deciding whether to implement. |
+| ClaudX's GroX-derived command spine, Crew, memory, durable ops, Mission Graph, A6 concepts | REJECT | Already native GroX capability; do not re-import or duplicate. |
 | Separate decisions ledger | REJECT | Avoid duplicate source of truth. |
 | Host-specific launchd heartbeat architecture | REJECT | Preserve host portability; only the abstract unattended-health idea may inform design. |
 | Sleeping retired Crew identities | REJECT | Preserve GroX purge rule. |
-| ClaudX's synthetic 57.4% token-savings claim | REJECT AS PROOF | Establish GroX evidence independently. |
-| Removing `orchestration-evaluation-analyst` because ClaudX removed a similar role | REJECT AS BASIS | GroX role decisions require GroX authority/capability evidence. |
+| ClaudX's synthetic 57.4% token-savings claim as GroX proof | REJECT | Establish GroX evidence independently. |
+| Removing `orchestration-evaluation-analyst` because ClaudX removed a similar role | REJECT | GroX role decisions require GroX authority/capability evidence. |
 
 ## Execution sequence
 

--- a/docs/stewardship/ROADMAP.md
+++ b/docs/stewardship/ROADMAP.md
@@ -31,6 +31,7 @@ The command architecture is native to the Vessel:
 - A7 Apex Qualification qualified with long-horizon recovery, independently verified contradiction synthesis, hard Mission cost ceilings, prompt-injection resistance, replayable evidence, and red-to-green adversarial canaries
 - Post-release Operational Audit 001 completed with CI supply-chain, dependency, compatibility, and repository-governance hardening
 - Canonical `main` protected by active repository rules requiring pull requests, all five canonical CI gates, strict up-to-date status, blocked deletion/non-fast-forward updates, and no bypass actors
+- External capability intake convention formalized and exercised against the pinned ClaudX comparative review without adding a command layer or duplicate decision store
 
 ## Apex critical path
 
@@ -85,8 +86,8 @@ The Commander approved the full set of actionable findings from the ClaudX compa
 
 Execution tracks:
 
-1. **#29 - External capability intake convention.** Formalize lightweight `adopt | adapt | harvest | reject` classification without adding a command layer or duplicate decision store.
-2. **#25 - Critical detector mutation proving.** Deliberately challenge high-consequence GroX health/governance tests and prove they fail for the intended reason before relying on them.
+1. **#29 - External capability intake convention: COMPLETE.** `docs/stewardship/EXTERNAL_CAPABILITY_INTAKE.md` now formalizes lightweight `ADOPT | ADAPT | HARVEST | REJECT` classification, evidence distinctions, authority boundaries, and a compact review record. It is exercised against the pinned ClaudX review without adding a command layer or duplicate decision store.
+2. **#25 - Critical detector mutation proving: NEXT.** Deliberately challenge high-consequence GroX health/governance tests and prove they fail for the intended reason before relying on them.
 3. **#26 - Native Vessel health surface.** Build a unified diagnostic health view from authoritative existing GroX services; inspection remains non-mutating by default.
 4. **#27 - Tiered reconstitution.** Add fast/targeted/full reconstitution selection without weakening source/state, recovery, authority, or Mission-resume gates.
 5. **#30 - Context heat experiment.** Test a GroX-native hot/warm/cold context model and bounded compression against long-horizon Mission/reconstitution evidence; external synthetic token-savings claims are not accepted as proof.


### PR DESCRIPTION
## Purpose
Complete Stage 0 of Post-Apex Operational Evolution Program 001 and close #29.

## Changes
- add `docs/stewardship/EXTERNAL_CAPABILITY_INTAKE.md` as the lightweight canonical `ADOPT | ADAPT | HARVEST | REJECT` review convention;
- distinguish external source facts/evidence from GroX inference and GroX-native evidence;
- require checks for existing coverage, circular novelty, duplication, authority/privacy/portability risk, and evidence thresholds;
- exercise the convention against the pinned ClaudX comparative review at `c82162b525ee183757e76300cc4a53f5643884f1`;
- update the program and Roadmap to mark Stage 0 complete and Stage 1 / #25 next;
- add Ship's Log 0040.

## Boundaries
Documentation/process clarification only. No runtime, Crew, authority, routing, persistence, package, release, or qualification change. No new command layer, approval body, external dependency, or duplicate decisions ledger.

Closes #29.