### PR TITLE
Stage 1: prove critical detectors by mutation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
         run: python -m pytest -q
       - name: Unittest regression
         run: python -m unittest discover -s tests -v
+      - name: Critical invariant mutation proof
+        if: matrix.python-version == '3.12'
+        run: python tests/mutation/run_critical_invariants.py
 
   bootstrap-portability:
     name: Wheel bootstrap portability

--- a/docs/history/ships-log/0041-critical-detectors-mutation-proven.md
+++ b/docs/history/ships-log/0041-critical-detectors-mutation-proven.md
@@ -1,0 +1,78 @@
+# Ship's Log 0041 — Critical Detectors Mutation-Proven
+
+**Date:** 2026-08-16
+
+**Program:** Post-Apex Operational Evolution Program 001
+
+**Stage:** 1 — Prove the detectors
+
+**Issue:** #25
+
+## Commander intent
+
+The Commander approved harvesting the detector-testing discipline identified during the ClaudX comparative review: a critical check is not strong evidence until GroX has deliberately weakened the production invariant and observed the intended detector turn red.
+
+## Implementation
+
+Stage 1 added a CI mutation proof harness at `tests/mutation/run_critical_invariants.py` and two direct regressions that closed specific coverage gaps:
+
+- executor self-verification rejection;
+- committed Mission cost reconstruction across restart.
+
+The harness applies isolated mutations only inside the CI checkout. It requires the targeted detector to fail, restores exact source bytes, reruns the detector green, continues across all selected cases, and fails if the mutated production paths are not Git-clean afterward.
+
+## Preserved red evidence
+
+PR #34 head:
+
+`16e893dd9471e01d708096ec030ee6aaa6200568`
+
+CI run:
+
+`31950179712`
+
+The normal full suites passed, and 11 selected mutations were killed. The final CI-action-pin mutation did not execute because the harness found two matching mutation seams and failed closed with:
+
+`source drift: expected exactly one mutation seam, found 2`
+
+No mutation survived. Source restoration remained clean.
+
+This red run is retained because it demonstrates that mutation targeting itself is bounded and will not silently edit an arbitrary matching location.
+
+## Remediation
+
+The CI pin mutation was narrowed to one exact regression-job workflow block. No production invariant was weakened and no detector expectation was relaxed.
+
+## Green qualification evidence
+
+PR #34 head:
+
+`988c97a390a31b5a255385149088ae7e67685fa9`
+
+CI run:
+
+`31950265325`
+
+Results:
+
+- pytest: **133 passed, 2 skipped, 19 subtests passed**;
+- unittest: **135 OK, 2 skipped**;
+- mutations: **12/12 KILLED**;
+- surviving mutations: **0**;
+- other mutation-proof failures: **0**;
+- source restoration: **clean**;
+- all five protected GroX CI jobs: **PASS**.
+
+The 12 proven detector classes cover source/state restore, semantic orchestrator admission, stale Crew purge, verifier independence, forged verification evidence, hard Mission cost budget, cost reconstruction on resume, graph Repair authority, Tool Gateway Repair authority, critical Commander escalation, fail-closed Vessel binding, and immutable GitHub Actions pins.
+
+The detailed matrix is canonicalized in `docs/verification/CRITICAL_INVARIANT_MUTATION_MATRIX.md`.
+
+## Authority result
+
+No weakened production variant is committed. Stage 1 changes verification infrastructure and regression coverage only. Commander authority, GorXu orchestration authority, Standing Crew, routing, Tool Gateway grants, persistence schema, production cost semantics, and package version are unchanged.
+
+## Program transition
+
+Stage 1 exit gate is satisfied.
+
+The next authorized workstream is **Stage 2 / issue #26: build the native GroX Vessel health surface**.

--- a/docs/stewardship/POST_APEX_EVOLUTION_PROGRAM_001.md
+++ b/docs/stewardship/POST_APEX_EVOLUTION_PROGRAM_001.md
@@ -1,6 +1,6 @@
 # Post-Apex Operational Evolution Program 001
 
-**Status:** IN EXECUTION — STAGE 0 COMPLETE; STAGE 1 NEXT
+**Status:** IN EXECUTION — STAGES 0-1 COMPLETE; STAGE 2 NEXT
 
 **Planning baseline:** `main@c93015278daf022b1c3d85fc8fb90a6fa52d8160`
 
@@ -52,7 +52,7 @@ The work is deliberately staged so later capabilities depend on trustworthy evid
 
 **Issue:** #29
 
-The lightweight GroX review convention is now defined in `docs/stewardship/EXTERNAL_CAPABILITY_INTAKE.md`.
+The lightweight GroX review convention is defined in `docs/stewardship/EXTERNAL_CAPABILITY_INTAKE.md`.
 
 It establishes:
 
@@ -64,31 +64,62 @@ It establishes:
 
 The convention is exercised against the pinned ClaudX review, including different decisions for independent seams from the same repository and explicit rejection of circular GroX-derived material.
 
-**Exit condition:** PASSED. One canonical convention/template exists and the ClaudX review is represented through it without architectural duplication.
+**Exit condition:** PASSED.
 
-### Stage 1 - Prove the detectors — NEXT
+### Stage 1 - Prove the detectors — COMPLETE
 
 **Issue:** #25
 
-Mutation-challenge the highest-consequence existing health, authority, recovery, identity, verification, bootstrap, and cost-control invariants.
+Stage 1 mutation-challenged the high-consequence restore, command-identity, stale-Crew purge, verification, cost, Repair authority, critical escalation, bootstrap, and CI supply-chain detectors.
 
-Priority order:
+Canonical evidence is recorded in `docs/verification/CRITICAL_INVARIANT_MUTATION_MATRIX.md`.
+
+The proof discipline is now executable in canonical CI through `tests/mutation/run_critical_invariants.py` on the required Python 3.12 regression job. Every selected mutation is applied only to the CI checkout, the targeted detector must go red, exact source bytes are restored, the same detector must return green, and the final mutated-source paths must be Git-clean.
+
+Permanent coverage added in Stage 1 includes:
+
+- direct executor/self-verifier rejection in `tests/unit/test_verification.py`;
+- committed Mission cost reconstruction across restart in `tests/integration/test_cost_recovery.py`.
+
+Preserved red harness evidence:
+
+- PR #34 head `16e893dd9471e01d708096ec030ee6aaa6200568`, run `31950179712`;
+- normal suites green;
+- 11 mutations killed, 0 survived;
+- the CI pin mutation failed closed before mutation because the initial seam was ambiguous (`expected exactly one mutation seam, found 2`);
+- source restoration remained clean.
+
+The harness was corrected by narrowing only that mutation target. No production invariant was changed to clear the red run.
+
+Green qualification evidence:
+
+- PR #34 head `988c97a390a31b5a255385149088ae7e67685fa9`, run `31950265325`;
+- pytest **133 passed, 2 skipped, 19 subtests passed**;
+- unittest **135 OK, 2 skipped**;
+- **12/12 mutations KILLED**;
+- **0 survived**;
+- **0 other mutation-proof failures**;
+- `source_restored_clean=true`;
+- all five canonical CI jobs passed.
+
+The proven mutations cover:
 
 1. source/state restore compatibility;
-2. sole-orchestrator and Crew admission invariants;
-3. stale/retired Crew operational purge;
-4. verifier independence and forged-verifier resistance;
-5. Mission cost commitment/resume accounting;
-6. Repair/authority boundaries and no authority widening;
-7. fail-closed Vessel-root bootstrap;
-8. critical escalation behavior;
-9. protected CI/action-pin contracts where practical.
+2. semantic orchestrator Crew admission;
+3. stale Crew performance-state purge;
+4. verifier self-independence;
+5. forged graph-verification evidence resistance;
+6. hard Mission cost-budget boundary;
+7. committed-cost reconstruction on resume;
+8. graph Repair authorization;
+9. Tool Gateway Repair boundary;
+10. critical Commander escalation;
+11. fail-closed unbound Vessel-root bootstrap;
+12. immutable GitHub Actions pins.
 
-Every selected detector must be observed failing against a deliberate isolated mutation for the intended reason before it is treated as proven.
+**Exit condition:** PASSED. The critical-invariant mutation matrix records production seam, targeted detector, observed red result, restored green result, and the preserved fail-closed harness run.
 
-**Exit condition:** a critical-invariant mutation matrix records mutation, expected red signal, observed red signal, restored green result, and any strengthened tests.
-
-### Stage 2 - Native Vessel health surface
+### Stage 2 - Native Vessel health surface — NEXT
 
 **Issue:** #26
 

--- a/docs/stewardship/ROADMAP.md
+++ b/docs/stewardship/ROADMAP.md
@@ -2,7 +2,7 @@
 
 ## Current position
 
-GroX `v0.7.1` is the current released post-Apex operational-hardening baseline. `v0.7.0` remains the first released Apex-qualified Vessel baseline. The Vessel has a full 82-Crew standing company, project/session-bound GorXu cognition, private operational-state recovery, durable source synchronization to GitHub, persistent canonical CI with immutable action pinning and Python 3.11-3.14 regression coverage, portable fail-closed Vessel binding, protected canonical `main`, and qualified A1/A2/A3/A4/A5/A6/A7 stages.
+GroX `v0.7.1` is the current released post-Apex operational-hardening baseline. `v0.7.0` remains the first released Apex-qualified Vessel baseline. The Vessel has a full 82-Crew standing company, project/session-bound GorXu cognition, private operational-state recovery, durable source synchronization to GitHub, persistent canonical CI with immutable action pinning and Python 3.11-3.14 regression coverage, portable fail-closed Vessel binding, protected canonical `main`, qualified A1/A2/A3/A4/A5/A6/A7 stages, and a continuously executable critical-invariant mutation proof on the Python 3.12 CI gate.
 
 The command architecture is native to the Vessel:
 
@@ -32,6 +32,7 @@ The command architecture is native to the Vessel:
 - Post-release Operational Audit 001 completed with CI supply-chain, dependency, compatibility, and repository-governance hardening
 - Canonical `main` protected by active repository rules requiring pull requests, all five canonical CI gates, strict up-to-date status, blocked deletion/non-fast-forward updates, and no bypass actors
 - External capability intake convention formalized and exercised against the pinned ClaudX comparative review without adding a command layer or duplicate decision store
+- Critical detector mutation proving established for 12 high-consequence restore, command-identity, stale-Crew, verification, cost, authority, escalation, bootstrap, and CI supply-chain invariants
 
 ## Apex critical path
 
@@ -86,9 +87,9 @@ The Commander approved the full set of actionable findings from the ClaudX compa
 
 Execution tracks:
 
-1. **#29 - External capability intake convention: COMPLETE.** `docs/stewardship/EXTERNAL_CAPABILITY_INTAKE.md` now formalizes lightweight `ADOPT | ADAPT | HARVEST | REJECT` classification, evidence distinctions, authority boundaries, and a compact review record. It is exercised against the pinned ClaudX review without adding a command layer or duplicate decision store.
-2. **#25 - Critical detector mutation proving: NEXT.** Deliberately challenge high-consequence GroX health/governance tests and prove they fail for the intended reason before relying on them.
-3. **#26 - Native Vessel health surface.** Build a unified diagnostic health view from authoritative existing GroX services; inspection remains non-mutating by default.
+1. **#29 - External capability intake convention: COMPLETE.** `docs/stewardship/EXTERNAL_CAPABILITY_INTAKE.md` formalizes lightweight `ADOPT | ADAPT | HARVEST | REJECT` classification, evidence distinctions, authority boundaries, and a compact review record. It is exercised against the pinned ClaudX review without adding a command layer or duplicate decision store.
+2. **#25 - Critical detector mutation proving: COMPLETE.** `docs/verification/CRITICAL_INVARIANT_MUTATION_MATRIX.md` records 12/12 killed mutations. Run `31950179712` is preserved as the fail-closed red harness case; run `31950265325` passed all five CI gates with pytest **133 passed, 2 skipped, 19 subtests**, unittest **135 OK, 2 skipped**, 12 killed mutations, zero survivors, and clean source restoration.
+3. **#26 - Native Vessel health surface: NEXT.** Build a unified diagnostic health view from authoritative existing GroX services; inspection remains non-mutating by default and critical health detectors inherit the Stage 1 mutation-proof discipline.
 4. **#27 - Tiered reconstitution.** Add fast/targeted/full reconstitution selection without weakening source/state, recovery, authority, or Mission-resume gates.
 5. **#30 - Context heat experiment.** Test a GroX-native hot/warm/cold context model and bounded compression against long-horizon Mission/reconstitution evidence; external synthetic token-savings claims are not accepted as proof.
 6. **#28 - A6 longitudinal operational drift analysis.** Extend A6 with protected-baseline trend analysis from real Mission trajectories while preserving non-self-activation and first-class invariant failures.

--- a/docs/verification/CRITICAL_INVARIANT_MUTATION_MATRIX.md
+++ b/docs/verification/CRITICAL_INVARIANT_MUTATION_MATRIX.md
@@ -1,0 +1,101 @@
+# Critical Invariant Mutation Matrix
+
+**Program:** Post-Apex Operational Evolution Program 001
+
+**Stage:** 1 — Prove the detectors
+
+**Issue:** #25
+
+**Candidate branch:** `verification/stage1-critical-detector-mutations`
+
+## Purpose
+
+This matrix records whether selected high-consequence GroX detectors actually turn red when the production invariant they protect is deliberately weakened.
+
+The mutation runner never commits weakened source. For each mutation it:
+
+1. requires one exact production mutation seam;
+2. applies the mutation only in the CI checkout;
+3. runs the targeted production-path regression and requires that exact detector to fail;
+4. restores the exact original bytes in a `finally` block;
+5. reruns the same detector and requires green;
+6. continues through the remaining mutations even if one proof fails;
+7. requires the mutated source paths to be Git-clean after the matrix completes.
+
+A detector is marked **KILLED** only when the targeted regression goes red under the mutation and green after exact restoration.
+
+## Preserved red harness evidence
+
+The first complete harness attempt ran on PR #34 head `16e893dd9471e01d708096ec030ee6aaa6200568` in CI run `31950179712`.
+
+The normal regression suites were green, but the Python 3.12 job correctly failed closed during the mutation phase:
+
+- 11/12 mutations were killed;
+- 0 mutations survived;
+- the immutable CI-action-pin mutation did not execute because its initial search seam matched two `actions/checkout` uses in the workflow;
+- the harness reported `source drift: expected exactly one mutation seam, found 2`;
+- source restoration remained clean.
+
+This red run is preserved as evidence that the mutation harness itself refuses ambiguous targeting rather than modifying an arbitrary occurrence.
+
+The only remediation was to narrow the CI-action mutation seam to the regression-job checkout/setup-python block. No production invariant or detector was weakened to clear the run.
+
+## Green mutation qualification evidence
+
+PR #34 head `988c97a390a31b5a255385149088ae7e67685fa9` ran as CI `31950265325`.
+
+Python 3.12 recorded:
+
+- pytest: **133 passed, 2 skipped, 19 subtests passed**;
+- unittest: **135 tests OK, 2 skipped**;
+- mutation proof: **12/12 KILLED**;
+- survived mutations: **0**;
+- other mutation-proof failures: **0**;
+- `source_restored_clean=true`.
+
+All five canonical CI jobs passed.
+
+## Matrix
+
+| # | Invariant | Production mutation | Target detector | Red result | Restored result |
+|---|---|---|---|---|---|
+| 1 | Snapshot restore enforces source compatibility unless ancestor allowance is explicit | `PersistenceManager.restore_snapshot` changes `enforce_source_binding=True` to `False` | `PersistencePlaneTests.test_restore_rejects_source_mismatch_without_explicit_ancestor_allowance` | KILLED | GREEN |
+| 2 | Semantic orchestrator identities cannot enter Standing Crew | Crew ID/title semantic orchestrator filter returns `False` unconditionally | `SpineTest.test_orchestrator_identity_variants_cannot_be_crew` | KILLED | GREEN |
+| 3 | Reconstitution purges stale Crew adaptive/performance state | stale `crew_performance` DELETE changed to non-mutating SELECT | `SpineTest.test_reconstitution_purges_stale_crew_operational_state` | KILLED | GREEN |
+| 4 | Executor cannot verify its own result | executor/verifier equality rejection disabled | `IndependentVerifierTests.test_same_executor_cannot_verify_own_result` | KILLED | GREEN |
+| 5 | Crew cannot forge trusted graph verification evidence | `graph_verification` evidence stripping disabled | `ApexQualificationGauntlet.test_non_verifier_cannot_forge_graph_verification_evidence` | KILLED | GREEN |
+| 6 | Mission may spend exactly its budget but must stop before overspend | cost reservation boundary changed from `<= max` to strict `< max` | `ApexQualificationGauntlet.test_fixed_mission_cost_budget_stops_before_overspend` | KILLED | GREEN |
+| 7 | Resume reconstitutes previously committed cost before authorizing more work | resumed `spent_cost` forced to `0.0` | `CostRecoveryTests.test_resume_reconstitutes_committed_cost_before_spending` | KILLED | GREEN |
+| 8 | Mission Graph Repair requires explicit GorXu mutation authorization | graph Repair authorization guard disabled | `MissionGraphIntegrationTests.test_graph_repair_requires_explicit_mutation_authority` | KILLED | GREEN |
+| 9 | Injected filesystem mutation grants remain unusable outside Repair | Tool Gateway Repair-mode defense disabled | `GatewayTest.test_execute_write_denied_even_if_grant_is_injected` | KILLED | GREEN |
+| 10 | Critical-risk exceptions escalate to Commander | critical-risk term removed from escalation condition | `DurableOperationsIntegrationTests.test_critical_exception_escalates_to_commander_without_automatic_consultation` | KILLED | GREEN |
+| 11 | Installed runtime without a Vessel root fails closed | final `VesselRootError` replaced with fabricated current directory root | `VesselRootTests.test_unbound_installed_runtime_refuses_empty_vessel` | KILLED | GREEN |
+| 12 | Third-party Actions remain pinned to immutable full commit SHAs | one regression-job checkout pin changed to mutable `@v7` | `CISupplyChainTest.test_external_actions_are_pinned_to_full_commit_sha` | KILLED | GREEN |
+
+## New detector coverage added in Stage 1
+
+Two gaps warranted permanent regression tests rather than relying only on indirect coverage:
+
+- `tests/unit/test_verification.py` directly proves the verifier rejects executor self-verification;
+- `tests/integration/test_cost_recovery.py` proves a restart reconstructs committed graph cost and cannot authorize a third paid Order after the Mission budget was already committed.
+
+The mutation matrix then proved both new detectors fail when their production seams are weakened.
+
+## Authority and architecture result
+
+Stage 1 changes verification infrastructure and tests only. It does not:
+
+- change Commander or GorXu authority;
+- change Crew membership or routing;
+- grant Repair capability;
+- alter persistence schema;
+- alter production cost semantics;
+- weaken source/state restore;
+- change the released package version;
+- create a new qualification stage.
+
+The deliberate weakened variants exist only transiently in the CI checkout and are restored before the mutation step succeeds.
+
+## Exit gate
+
+**PASSED.** The selected critical detector set has a replayable matrix showing the production seam, exact target detector, observed red result, restored green result, and preserved fail-closed harness evidence. Stage 2 may build the Vessel health surface on these proven detector foundations.

--- a/tests/integration/test_cost_recovery.py
+++ b/tests/integration/test_cost_recovery.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import json
+import unittest
+
+from grox.pilot import PilotGorXu
+from tests.integration.test_mission_graph import graph_vessel
+
+
+class CrashOnCrewAfterCommit:
+    def __init__(self, base, crew_id: str):
+        self.base = base
+        self.crew_id = crew_id
+        self.crashed = False
+
+    def execute(self, order):
+        if order.assigned_crew == self.crew_id and not self.crashed:
+            self.crashed = True
+            raise SystemExit("injected crash after graph cost commitment")
+        return self.base.execute(order)
+
+
+class CostRecoveryTests(unittest.TestCase):
+    def test_resume_reconstitutes_committed_cost_before_spending(self) -> None:
+        td, root, pilot = graph_vessel()
+        try:
+            directive = "Resume a cost-bounded Mission without spending committed cost twice."
+            plan = {
+                "commander_intent": directive,
+                "objective": "Prove committed cost remains charged across restart.",
+                "budget": {"max_nodes": 5, "max_parallel": 1, "max_replans": 0, "max_cost_units": 2.0},
+                "nodes": [
+                    {
+                        "node_id": "one", "objective": "Cost recovery step one", "mode": "inspect",
+                        "dependencies": [], "candidate_crew_ids": ["systems-architect"],
+                        "required_capabilities": ["repo_read"], "scope": ["."],
+                        "budget": {"cost_units": 1.0},
+                    },
+                    {
+                        "node_id": "two", "objective": "Cost recovery step two", "mode": "inspect",
+                        "dependencies": ["one"], "candidate_crew_ids": ["researcher"],
+                        "required_capabilities": ["repo_read"], "scope": ["."],
+                        "budget": {"cost_units": 1.0},
+                    },
+                    {
+                        "node_id": "three", "objective": "Cost recovery step three", "mode": "inspect",
+                        "dependencies": ["two"], "candidate_crew_ids": ["data-analyst"],
+                        "required_capabilities": ["repo_read"], "scope": ["."],
+                        "budget": {"cost_units": 1.0},
+                    },
+                ],
+            }
+            pilot.executor = CrashOnCrewAfterCommit(pilot.executor, "researcher")
+            with self.assertRaises(SystemExit):
+                pilot.command_graph(directive, plan=plan, plan_source="stage1-cost-resume")
+
+            mission_id = pilot.store.recent_missions(1)[0]["mission_id"]
+            before = pilot.store.mission(mission_id)
+            committed = [
+                json.loads(event["content"])
+                for event in before["graph_events"]
+                if event["event_type"] == "cost_committed"
+            ]
+            self.assertEqual(sum(float(event["cost_units"]) for event in committed), 2.0)
+            self.assertEqual(len(before["orders"]), 2)
+            pilot.store.close()
+
+            resumed_pilot = PilotGorXu(root, reasoner=None)
+            resumed = resumed_pilot.resume_graph(mission_id)
+
+            self.assertEqual(resumed["status"], "needs_pilot_decision")
+            self.assertEqual(resumed["resume_count"], 1)
+            self.assertEqual(resumed["synthesis"]["cost_units"], 2.0)
+            self.assertEqual(resumed["synthesis"]["cost_budget"], 2.0)
+            self.assertIn("two", resumed["synthesis"]["unresolved_nodes"])
+
+            after = resumed_pilot.store.mission(mission_id)
+            self.assertEqual(len(after["orders"]), 2, "resume must not create another paid Order after budget exhaustion")
+            self.assertTrue(
+                any(event["event_type"] == "cost_budget_exhausted" for event in after["graph_events"]),
+                "resume must record the cost-budget stop",
+            )
+        finally:
+            td.cleanup()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/mutation/run_critical_invariants.py
+++ b/tests/mutation/run_critical_invariants.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Prove critical GroX detectors by killing isolated production mutations.
+
+This harness never commits weakened source. Each mutation is applied to the CI
+checkout, its targeted production-path regression must turn red, the exact
+original bytes are restored in a finally block, and the same regression must
+then return green. All mutations run even if an earlier one is not killed so a
+single broken detector cannot blind the rest of the proof surface.
+"""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+from typing import Iterable
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+@dataclass(frozen=True)
+class MutationSpec:
+    name: str
+    invariant: str
+    path: str
+    old: str
+    new: str
+    nodeid: str
+
+
+@dataclass
+class MutationResult:
+    name: str
+    invariant: str
+    path: str
+    nodeid: str
+    source_match_count: int
+    red_returncode: int | None = None
+    target_failed: bool = False
+    restored_green: bool = False
+    restored_exact: bool = False
+    status: str = "ERROR"
+    detail: str = ""
+
+
+SPECS: tuple[MutationSpec, ...] = (
+    MutationSpec(
+        name="source-state-binding",
+        invariant="Snapshot restore must enforce source compatibility unless ancestor allowance is explicit.",
+        path="src/grox/persistence.py",
+        old="            enforce_source_binding=True,\n",
+        new="            enforce_source_binding=False,\n",
+        nodeid="tests/integration/test_persistence_planes.py::PersistencePlaneTests::test_restore_rejects_source_mismatch_without_explicit_ancestor_allowance",
+    ),
+    MutationSpec(
+        name="semantic-orchestrator-admission",
+        invariant="Semantic orchestrator identity variants must never enter Standing Crew.",
+        path="src/grox/crew/roster.py",
+        old='    return "orchestrator" in cid or "orchestrator" in normalized_title\n',
+        new="    return False\n",
+        nodeid="tests/contracts/test_command_spine.py::SpineTest::test_orchestrator_identity_variants_cannot_be_crew",
+    ),
+    MutationSpec(
+        name="stale-crew-performance-purge",
+        invariant="Reconstitution must purge stale Crew adaptive/performance state while preserving audit history.",
+        path="src/grox/crew/roster.py",
+        old='    store.db.execute(f"DELETE FROM crew_performance WHERE crew_id IN ({placeholders})", stale_ids)\n',
+        new='    store.db.execute(f"SELECT crew_id FROM crew_performance WHERE crew_id IN ({placeholders})", stale_ids)\n',
+        nodeid="tests/contracts/test_command_spine.py::SpineTest::test_reconstitution_purges_stale_crew_operational_state",
+    ),
+    MutationSpec(
+        name="verifier-self-independence",
+        invariant="An executor must never verify its own result.",
+        path="src/grox/verification/core.py",
+        old="        if executor_id==verifier_id: return False,'Verifier is not independent from executor'\n",
+        new="        if False: return False,'Verifier is not independent from executor'\n",
+        nodeid="tests/unit/test_verification.py::IndependentVerifierTests::test_same_executor_cannot_verify_own_result",
+    ),
+    MutationSpec(
+        name="forged-graph-verification-filter",
+        invariant="Crew-provided graph_verification evidence must be stripped before persistence or synthesis.",
+        path="src/grox/graph/runtime.py",
+        old='        result.evidence = [evidence for evidence in result.evidence if evidence.kind != "graph_verification"]\n',
+        new="        result.evidence = list(result.evidence)\n",
+        nodeid="tests/integration/test_apex_qualification.py::ApexQualificationGauntlet::test_non_verifier_cannot_forge_graph_verification_evidence",
+    ),
+    MutationSpec(
+        name="hard-cost-budget-boundary",
+        invariant="A Mission may spend exactly its budget but must stop before overspend.",
+        path="src/grox/graph/runtime.py",
+        old="                if spent_cost + reserved_cost + node_cost <= plan.budget.max_cost_units + 1e-12:\n",
+        new="                if spent_cost + reserved_cost + node_cost < plan.budget.max_cost_units - 1e-12:\n",
+        nodeid="tests/integration/test_apex_qualification.py::ApexQualificationGauntlet::test_fixed_mission_cost_budget_stops_before_overspend",
+    ),
+    MutationSpec(
+        name="resume-committed-cost-reconstitution",
+        invariant="Resume must reconstruct previously committed Mission cost before authorizing more work.",
+        path="src/grox/graph/runtime.py",
+        old="        spent_cost = self._committed_cost(mission_id)\n\n        unresolved_reason: str | None = None\n",
+        new="        spent_cost = 0.0\n\n        unresolved_reason: str | None = None\n",
+        nodeid="tests/integration/test_cost_recovery.py::CostRecoveryTests::test_resume_reconstitutes_committed_cost_before_spending",
+    ),
+    MutationSpec(
+        name="graph-repair-authorization",
+        invariant="Mission Graph Repair nodes require explicit GorXu mutation authorization.",
+        path="src/grox/graph/runtime.py",
+        old='        if any(n.mode is MissionMode.repair for n in plan.nodes) and not allow_repair:\n            raise GraphExecutionError("Mission Graph repair nodes require explicit Pilot mutation authorization")\n',
+        new='        if False and any(n.mode is MissionMode.repair for n in plan.nodes) and not allow_repair:\n            raise GraphExecutionError("Mission Graph repair nodes require explicit Pilot mutation authorization")\n',
+        nodeid="tests/integration/test_mission_graph.py::MissionGraphIntegrationTests::test_graph_repair_requires_explicit_mutation_authority",
+    ),
+    MutationSpec(
+        name="tool-gateway-repair-boundary",
+        invariant="Injected filesystem mutation grants remain unusable outside explicit Repair mode.",
+        path="src/grox/tools/gateway.py",
+        old='        if action in {"fs_write", "mcp_mutate"} and order.mode is not MissionMode.repair:\n            raise ToolDenied(f"{action} requires explicit Repair authority")\n',
+        new='        if False and action in {"fs_write", "mcp_mutate"} and order.mode is not MissionMode.repair:\n            raise ToolDenied(f"{action} requires explicit Repair authority")\n',
+        nodeid="tests/unit/test_gateway.py::GatewayTest::test_execute_write_denied_even_if_grant_is_injected",
+    ),
+    MutationSpec(
+        name="critical-commander-escalation",
+        invariant="Critical-risk exceptions must escalate to Commander rather than auto-recover.",
+        path="src/grox/operations.py",
+        old="        if risk is RiskClass.critical or irreversible or material_intent_change:\n",
+        new="        if irreversible or material_intent_change:\n",
+        nodeid="tests/integration/test_durable_operations.py::DurableOperationsIntegrationTests::test_critical_exception_escalates_to_commander_without_automatic_consultation",
+    ),
+    MutationSpec(
+        name="unbound-vessel-fail-closed",
+        invariant="An installed runtime outside a valid Vessel must refuse to fabricate an empty root.",
+        path="src/grox/vessel.py",
+        old='    raise VesselRootError(\n        "No GroX Vessel root found. Run from a GroX source checkout or set "\n        "GROX_VESSEL_ROOT to the checkout root. Refusing to start an empty Vessel."\n    )\n',
+        new="    return Path(cwd or Path.cwd()).resolve()\n",
+        nodeid="tests/unit/test_vessel_root.py::VesselRootTests::test_unbound_installed_runtime_refuses_empty_vessel",
+    ),
+    MutationSpec(
+        name="ci-action-immutable-pin",
+        invariant="Third-party GitHub Actions must remain pinned to immutable full commit SHAs.",
+        path=".github/workflows/ci.yml",
+        old="uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+        new="uses: actions/checkout@v7",
+        nodeid="tests/contracts/test_ci_supply_chain.py::CISupplyChainTest::test_external_actions_are_pinned_to_full_commit_sha",
+    ),
+)
+
+
+def run_pytest(nodeid: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONHASHSEED"] = "0"
+    return subprocess.run(
+        [sys.executable, "-m", "pytest", "-q", nodeid],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=180,
+        check=False,
+    )
+
+
+def target_failed(nodeid: str, completed: subprocess.CompletedProcess[str]) -> bool:
+    output = f"{completed.stdout}\n{completed.stderr}"
+    leaf = nodeid.rsplit("::", 1)[-1]
+    return completed.returncode != 0 and leaf in output and "failed" in output.lower()
+
+
+def prove(spec: MutationSpec) -> MutationResult:
+    path = ROOT / spec.path
+    original = path.read_text(encoding="utf-8")
+    count = original.count(spec.old)
+    result = MutationResult(
+        name=spec.name,
+        invariant=spec.invariant,
+        path=spec.path,
+        nodeid=spec.nodeid,
+        source_match_count=count,
+    )
+    if count != 1:
+        result.detail = f"source drift: expected exactly one mutation seam, found {count}"
+        return result
+
+    mutated = original.replace(spec.old, spec.new, 1)
+    red: subprocess.CompletedProcess[str] | None = None
+    try:
+        path.write_text(mutated, encoding="utf-8")
+        red = run_pytest(spec.nodeid)
+        result.red_returncode = red.returncode
+        result.target_failed = target_failed(spec.nodeid, red)
+    except Exception as exc:  # keep running remaining proofs
+        result.detail = f"mutation execution error: {type(exc).__name__}: {exc}"
+    finally:
+        path.write_text(original, encoding="utf-8")
+        result.restored_exact = path.read_text(encoding="utf-8") == original
+
+    if not result.restored_exact:
+        result.detail = "failed to restore exact source bytes"
+        return result
+
+    green = run_pytest(spec.nodeid)
+    result.restored_green = green.returncode == 0
+
+    if result.target_failed and result.restored_green:
+        result.status = "KILLED"
+        result.detail = "target regression went red under mutation and green after exact restoration"
+    elif not result.target_failed:
+        output = ""
+        if red is not None:
+            output = (red.stdout + "\n" + red.stderr)[-1200:].replace("\n", " | ")
+        result.status = "SURVIVED"
+        result.detail = f"target detector did not fail for the intended target; tail={output}"
+    else:
+        result.status = "RESTORE_FAILED"
+        result.detail = (green.stdout + "\n" + green.stderr)[-1200:].replace("\n", " | ")
+    return result
+
+
+def source_diff_clean(paths: Iterable[str]) -> bool:
+    cp = subprocess.run(
+        ["git", "diff", "--exit-code", "--", *sorted(set(paths))],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if cp.returncode != 0:
+        print(cp.stdout)
+        print(cp.stderr, file=sys.stderr)
+    return cp.returncode == 0
+
+
+def main() -> int:
+    results: list[MutationResult] = []
+    for spec in SPECS:
+        result = prove(spec)
+        results.append(result)
+        print(f"MUTATION {result.name}: {result.status} — {result.detail}")
+
+    clean = source_diff_clean(spec.path for spec in SPECS)
+    report = {
+        "schema": "grox-critical-invariant-mutations-v1",
+        "mutations": [asdict(result) for result in results],
+        "summary": {
+            "total": len(results),
+            "killed": sum(result.status == "KILLED" for result in results),
+            "survived": sum(result.status == "SURVIVED" for result in results),
+            "other_failures": sum(result.status not in {"KILLED", "SURVIVED"} for result in results),
+            "source_restored_clean": clean,
+        },
+    }
+    print("MUTATION_MATRIX_JSON=" + json.dumps(report, sort_keys=True))
+    all_killed = all(result.status == "KILLED" for result in results)
+    return 0 if all_killed and clean else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/mutation/run_critical_invariants.py
+++ b/tests/mutation/run_critical_invariants.py
@@ -139,8 +139,8 @@ SPECS: tuple[MutationSpec, ...] = (
         name="ci-action-immutable-pin",
         invariant="Third-party GitHub Actions must remain pinned to immutable full commit SHAs.",
         path=".github/workflows/ci.yml",
-        old="uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
-        new="uses: actions/checkout@v7",
+        old="        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1\n      - name: Set up Python\n        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0\n        with:\n          python-version: ${{ matrix.python-version }}\n",
+        new="        uses: actions/checkout@v7 # deliberate mutation\n      - name: Set up Python\n        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0\n        with:\n          python-version: ${{ matrix.python-version }}\n",
         nodeid="tests/contracts/test_ci_supply_chain.py::CISupplyChainTest::test_external_actions_are_pinned_to_full_commit_sha",
     ),
 )

--- a/tests/unit/test_verification.py
+++ b/tests/unit/test_verification.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import unittest
+
+from grox.contracts import Evidence, TourResult
+from grox.verification.core import IndependentVerifier
+
+
+class IndependentVerifierTests(unittest.TestCase):
+    def test_same_executor_cannot_verify_own_result(self) -> None:
+        verifier = IndependentVerifier()
+        result = TourResult(
+            "ORD-self",
+            "code-reviewer",
+            "completed",
+            "self-verification attempt",
+            [Evidence("finding", {"claim": "evidence exists"})],
+        )
+
+        ok, message = verifier.verify("code-reviewer", "code-reviewer", result)
+
+        self.assertFalse(ok)
+        self.assertIn("not independent", message)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose
Complete Stage 1 / #25 of Post-Apex Operational Evolution Program 001 by continuously proving that high-consequence GroX detectors turn red when their protected production invariants are deliberately weakened.

## Changes
- add direct executor/self-verifier independence regression;
- add committed-cost resume regression;
- add an ephemeral mutation proof harness covering source/state restore, Crew command identity, stale Crew purge, verifier independence, forged verification, hard cost budget, resume cost accounting, graph Repair authority, Tool Gateway Repair authority, critical Commander escalation, fail-closed Vessel binding, and immutable CI action pins;
- run the mutation proof inside the existing required Python 3.12 regression gate after the normal complete suites;
- restore exact source bytes after every mutation and rerun the targeted regression green;
- continue through all mutation cases so one broken detector cannot hide the rest;
- record the canonical mutation matrix, preserved red harness evidence, Roadmap/program transition, and Ship's Log 0041.

## Evidence
Preserved red harness run `31950179712`: normal suites green; 11 mutations killed, zero survived, final CI-pin mutation refused to run because its initial seam matched two locations. Source restoration remained clean.

Corrected qualification run `31950265325`: pytest 133 passed / 2 skipped / 19 subtests, unittest 135 OK / 2 skipped, 12/12 mutations killed, zero survivors, zero other mutation-proof failures, source restored clean, all five canonical CI jobs green.

## Boundaries
No weakened implementation is committed. No Commander/GorXu/Crew authority, routing, persistence schema, production cost semantics, package version, or Apex stage is changed.

Closes #25.