### PR TITLE
Refocus GroX README as a high-signal entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,136 +1,341 @@
+<a id="readme-top"></a>
+
 <p align="center">
   <img src="assets/banner/grox-banner-hd-optimized.png" alt="GroX persistent AI command environment banner" width="100%">
 </p>
 
+<div align="center">
+
 # GroX
 
-**Latest release:** `v0.7.1`
-**Current source package:** `0.7.1`
-**Operating standard:** **APEX QUALIFIED**
-**Standing Crew:** **82** — 81 specialist-inspired Crew plus 1 native independent verifier
-**Canonical release source:** `f7ed57dc9dac2eb9de7857fffb743ecdf27f05f2`
+### Persistent AI command environment
 
-GroX is an independent, persistent AI command environment built around a clear chain of command:
+A persistent AI Vessel for translating **Commander intent into bounded Missions, durable execution, attributable evidence, independent verification, and recoverable continuity**.
 
-**Commander → Pilot GorXu → Divisions → Standing Crew**
+[![GroX CI](https://github.com/vessaxor-spec/GroX/actions/workflows/ci.yml/badge.svg)](https://github.com/vessaxor-spec/GroX/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/vessaxor-spec/GroX?label=release)](https://github.com/vessaxor-spec/GroX/releases/tag/v0.7.1)
 
-The Commander defines intent and retains final authority. Pilot GorXu is the Vessel's second-in-command and sole operational orchestrator. Divisions organize operational areas and Crew. Standing Crew perform bounded work through Mission Orders. Capabilities, tools, schedulers, memory, evaluators, and external systems are resources under this command relationship; they are not command layers.
+[**Explore the architecture**](docs/architecture/ARCHITECTURE.md) ·
+[**See current progress**](docs/stewardship/progress-tracker.md) ·
+[**View the roadmap**](docs/stewardship/ROADMAP.md) ·
+[**Meet the Crew**](docs/stewardship/CREW_ROSTER.md)
 
-Mission Control is a GroX-native policy and advisory service used by GorXu for governance, risk analysis, routing support, verification policy, evidence requirements, and operational intelligence. It does not form a second command spine.
+**Release:** `v0.7.1` · **Package:** `0.7.1` · **Operating standard:** `APEX QUALIFIED` · **Standing Crew:** `82`
 
-## Current qualification state
+</div>
 
-GroX `v0.7.1` is the current released post-Apex operational-hardening baseline. `v0.7.0` remains the first released Apex-qualified baseline.
+---
 
-- **A1 Cognitive Pilot:** SESSION-QUALIFIED with project-hosted GPT-5.6 Sol cognition and deterministic safe fallback.
-- **A2 Mission Graph Orchestration:** QUALIFIED.
-- **A3 Living Company Intelligence:** QUALIFIED.
-- **A4 Executive Exception Loop and Durable Operations:** QUALIFIED.
-- **A5 Governed Capability Expansion:** QUALIFIED.
-- **A6 Orchestration Intelligence and Self-Improvement:** QUALIFIED.
-- **A7 Apex Qualification Gauntlet:** QUALIFIED.
-- **GorXu operating standard:** **APEX QUALIFIED**.
+<details>
+<summary><strong>Table of contents</strong></summary>
 
-Apex is an evidence-backed operating standard, not additional authority. Future changes do not inherit Apex automatically; consequential changes must preserve Commander sovereignty, bounded authority, verifier independence, evidence integrity, recovery, and the qualified execution path through appropriate regression evidence.
+- [About GroX](#about-grox)
+- [How GroX works](#how-grox-works)
+- [What GroX owns](#what-grox-owns)
+- [Current state](#current-state)
+- [Qualified limits](#qualified-limits)
+- [Quick start](#quick-start)
+- [Persistence and recovery](#persistence-and-recovery)
+- [Repository map](#repository-map)
+- [Governance and evidence](#governance-and-evidence)
+- [Roadmap](#roadmap)
 
-## Core operating model
+</details>
 
-- The Commander sets intent and retains ultimate authority.
-- GorXu interprets intent, constructs and adapts Missions, consults relevant services and Crew, issues bounded Mission Orders, resolves ordinary reversible exceptions, and synthesizes outcomes.
-- Crew operate only within the authority granted for their current Mission Order.
-- Competence does not imply permission.
-- Inspection and mutation authority are structurally separate.
-- Crew may challenge assumptions, surface blockers, or recommend safer or better paths, but cannot widen their own scope.
-- Critical, irreversible, authority-divergent, or material intent-changing decisions return to the Commander.
-- Independent verification and attributable evidence are mandatory where policy requires them.
+## About GroX
 
-## Live Vessel
+GroX is an independent, persistent AI command environment built around one canonical command spine:
 
-The released Vessel includes:
+> **Commander → Pilot GorXu → Divisions → Standing Crew**
 
-- Commander Seat CLI and interactive bridge;
-- persistent least-privilege GitHub Actions CI on pull requests and `main`, including Python 3.11-3.14 regressions plus wheel-bootstrap portability, with immutable full-SHA action pinning;
-- active default-branch repository protection requiring pull requests and all five canonical CI gates, strict up-to-date checks, blocked deletion/non-fast-forward updates, and no configured bypass actors;
-- Pilot GorXu orchestration with provider-neutral cognition and deterministic safe fallback;
-- native Mission Control;
-- **82 Standing Crew** across nine Divisions;
-- durable Mission, Order, Evidence, Crew, memory, performance, graph, evaluation, exception, and recovery state;
-- Living Company Intelligence with attributable semantic, procedural, episodic, and Vessel memory plus bounded selective retrieval;
-- experienced eligible-Crew routing informed by evidence, reliability, load, cost, latency, and risk;
-- durable dependency-aware Mission Graph execution with parallel-ready scheduling and bounded replanning;
-- crash-safe same-Mission resume, checkpointing, cancellation, and journaled text-Repair compensation;
-- hard Mission cost ceilings with persisted cost commitments so restart cannot reset consumed budget;
-- independently verified contradiction synthesis that rejects forged verifier evidence, normalizes duplicate source contribution, and leaves unresolved ties unresolved;
-- Tool Gateway v2 with deny-wins action authorization;
-- governed isolated workspace execution with namespace-first and digest-pinned commissioned Docker fallback isolation;
-- memory-only secret aliases with explicit grants and output redaction;
-- exact-origin bounded HTTP(S) fetch plus offline Chromium screenshot/hash evidence capture;
-- pre-registered stdio MCP adapters with separately gated mutation authority;
-- replayable privacy-minimized orchestration evaluation with evidence-backed improvement proposals that cannot self-activate;
-- private integrity-checked `.groxstate` snapshot/restore with source-state compatibility enforcement.
+The Commander defines intent and retains final authority. Pilot GorXu is the Vessel's second-in-command and sole operational orchestrator. Divisions organize operational areas. Standing Crew perform bounded work through Mission Orders.
+
+Mission Control is a **GroX-native policy and advisory service** used by GorXu for governance, risk analysis, routing support, verification policy, evidence requirements, and operational intelligence. It is not a command layer and cannot become a parallel orchestrator.
+
+### Why this exists
+
+GroX is designed to make capable AI execution durable without making authority ambiguous. It is built to prevent several common failures in autonomous systems:
+
+- treating a model session as the whole system;
+- confusing competence with permission;
+- allowing Crew, tools, evaluators, or schedulers to become parallel orchestrators;
+- losing Mission state, evidence, or recovery context when a process or host disappears;
+- letting retries, replanning, or fallback silently widen authority;
+- allowing an executor to satisfy an independence requirement by verifying itself;
+- representing experiments, simulations, or staged behavior as stronger operational proof than the evidence supports;
+- allowing improvement proposals to self-activate without governed approval.
+
+## How GroX works
+
+GroX keeps command authority separate from the services and capabilities used to execute work:
+
+```text
+Commander intent
+  -> Pilot GorXu
+     -> consults Mission Control when required
+     -> constructs a Mission or Mission Graph
+     -> selects eligible Standing Crew
+     -> issues bounded Mission Orders
+        -> governed capabilities and tools
+        -> attributable evidence
+     -> independent verification when required
+     -> Pilot synthesis
+     -> Commander escalation for critical, irreversible,
+        authority-divergent, or material intent-changing decisions
+```
+
+Capabilities, tools, schedulers, memory, evaluators, and external systems are resources under this relationship. They are not command layers.
+
+### Core operating principles
+
+1. **Commander sovereignty.** The Commander sets intent and retains ultimate authority.
+2. **One operational orchestrator.** GorXu is the sole operational orchestrator; no Crew member or subsystem may become a rival command spine.
+3. **Competence is not permission.** Crew may act only within the authority granted by the current Mission Order.
+4. **Inspection is not mutation.** Inspect and Repair authority remain structurally separate.
+5. **Deny wins.** Tool access is capability-gated and constrained by Mission Order, Crew capability, and host policy.
+6. **Verification remains independent.** Where policy requires independence, the verifier must differ from the executor and evidence must be attributable.
+7. **Failure narrows authority.** Recovery, fallback, and replanning may restore reversible execution but may not widen scope or change Commander intent.
+8. **Continuity requires evidence.** Persistence, recovery, and reconstitution are operational infrastructure, not assumptions about a surviving process.
+
+Canonical builder constraints are defined in [`AI_INSTRUCTIONS.md`](AI_INSTRUCTIONS.md). Detailed command and runtime architecture is defined in [`docs/architecture/ARCHITECTURE.md`](docs/architecture/ARCHITECTURE.md).
+
+## What GroX owns
+
+| GroX owns | GroX deliberately does not own |
+|---|---|
+| interpretation and execution of Commander intent | authority to replace or silently rewrite Commander intent |
+| Mission and Mission Graph orchestration | self-authorizing goals or a second command spine |
+| Standing Crew selection and bounded Mission Orders | Crew self-promotion, self-authorization, or scope widening |
+| native Mission Control policy and advisory support | a parallel Mission Control command hierarchy |
+| capability and Tool Gateway authorization | permission to exceed host policy or Mission authority |
+| evidence capture and verifier assignment | executor self-verification where independence is required |
+| durable operational state, snapshots, and reconstitution | public storage of private runtime state or secrets |
+| evidence-backed evaluation and improvement proposals | automatic self-activation of proposed changes |
+
+## Current state
+
+GroX has completed the A1-A7 Apex qualification path and is operating in protected post-Apex evolution.
+
+| Surface | Current state |
+|---|---|
+| Current released baseline | [`v0.7.1`](https://github.com/vessaxor-spec/GroX/releases/tag/v0.7.1), post-Apex operational hardening |
+| First Apex-qualified release | `v0.7.0` |
+| Operating standard | **APEX QUALIFIED** |
+| Command spine | Commander → Pilot GorXu → Divisions → Standing Crew |
+| Standing company | **82 Crew** across nine Divisions |
+| Canonical source | protected `main`; source may advance beyond the release through the governed PR/CI path |
+| CI boundary | Python 3.11-3.14 regressions plus wheel-bootstrap portability; five required gates |
+| Current evolution program | [`Post-Apex Operational Evolution Program 001`](docs/stewardship/POST_APEX_EVOLUTION_PROGRAM_001.md) |
+| Completed program work | capability intake, critical mutation proving, Vessel health, tiered reconstitution, controlled context heat/compression experiment |
+| Next program stage | **#28 A6 longitudinal operational drift analysis** |
+| Canonical current status | [`docs/stewardship/progress-tracker.md`](docs/stewardship/progress-tracker.md) |
+
+The live Vessel includes Commander Seat interfaces, durable Missions and Mission Graphs, 82 Standing Crew, attributable organizational memory, capability-gated execution, independent verification, crash-safe same-Mission recovery, bounded replanning, Tool Gateway v2, isolated workspace execution, exact-origin network access, offline browser evidence capture, pre-registered stdio MCP adapters, evaluation that cannot self-activate, read-only Vessel health, tiered reconstitution planning, and integrity-checked private state snapshots.
+
+<details>
+<summary><strong>Current qualification and evidence snapshot</strong></summary>
+
+### Apex qualification
+
+| Stage | Status |
+|---|---|
+| A1 Cognitive Pilot | SESSION-QUALIFIED |
+| A2 Mission Graph Orchestration | QUALIFIED |
+| A3 Living Company Intelligence | QUALIFIED |
+| A4 Executive Exception Loop and Durable Operations | QUALIFIED |
+| A5 Governed Capability Expansion | QUALIFIED |
+| A6 Orchestration Intelligence and Self-Improvement | QUALIFIED |
+| A7 Apex Qualification Gauntlet | QUALIFIED |
+| GorXu operating standard | **APEX QUALIFIED** |
+
+Apex is an evidence-backed regression boundary, not additional authority and not inherited permission for future changes.
+
+### Post-Apex control evidence
+
+Current protected evolution has added continuous proof around high-consequence controls:
+
+- **12/12** Stage 1 critical-detector mutations killed;
+- **7/7** Stage 2 Vessel-health mutations killed;
+- **9/9** Stage 3 reconstitution mutations killed;
+- native `grox health` remains read-only and isolated from Repair authority;
+- `grox reconstitution-plan` selects FAST, TARGETED, or FULL recovery scope without duplicating health truth or widening authority;
+- the controlled Stage 4 HOT/WARM/COLD experiment retained **100% of declared critical facts and retained provenance** while reducing the bounded corpus from 20,464 to 1,336 characters, a **93.47% controlled character reduction**;
+- that Stage 4 result is an experimental character-count result, not a production token, latency, or runtime-activation claim;
+- automatic Pilot context compression remains deferred until integrated operational evidence supports activation.
+
+Historical red runs remain evidence rather than being erased to create a clean narrative. Exact current milestones, run IDs, and qualification evidence are maintained in the [`Progress Tracker`](docs/stewardship/progress-tracker.md), [`Roadmap`](docs/stewardship/ROADMAP.md), and Ship's Log.
+
+</details>
 
 ## Qualified limits
 
 The Apex baseline does not claim unrestricted power. Current deliberate limits include:
 
-- cognition remains project/session-hosted with deterministic fallback;
+- cognition remains project/session-hosted with deterministic safe fallback;
 - unrestricted interactive desktop actuation is outside the qualified boundary;
-- arbitrary/networked third-party MCP processes are outside the qualified boundary;
-- runtime image pulls/builds are not implicit Crew authority;
+- arbitrary or networked third-party MCP processes are outside the qualified boundary;
+- runtime image pulls or builds are not implicit Crew authority;
 - generic compensation for arbitrary external systems is not claimed;
 - external-agent interoperability remains optional and grants no inherited GroX authority;
-- autonomous memory consolidation remains future evolution.
+- autonomous memory consolidation remains future evolution;
+- controlled context compression is not automatically active in Pilot runtime.
+
+A missing provider, unavailable isolation backend, stale evidence, or ambiguous recovery condition causes safe degradation or broader recovery requirements, never authority expansion.
 
 ## Quick start
 
+### Prerequisites
+
+- Python **3.11+**
+- Git
+
+### Install the Vessel
+
 ```bash
+git clone https://github.com/vessaxor-spec/GroX.git
+cd GroX
 python -m pip install -e .
+```
+
+For local testing:
+
+```bash
+python -m pip install -e '.[test]'
+pytest
+```
+
+### Inspect the Vessel
+
+```bash
 grox status
 grox roster
+grox health
+grox reconstitution-plan
+```
+
+### Run a bounded Mission
+
+```bash
 grox mission "Inspect the Vessel and report readiness" --mode inspect
+```
+
+### Enter the Commander bridge
+
+```bash
 grox bridge
 ```
 
-Vessel-root binding is explicit and fail-closed. GroX resolves `GROX_VESSEL_ROOT` first, then the current checkout ancestry, then the source-module ancestry used by an editable checkout. A non-editable installed CLI may operate from a valid GroX checkout or with `GROX_VESSEL_ROOT` set; outside a bound Vessel it refuses to start rather than constructing an empty company.
+Vessel-root binding is explicit and fail-closed. GroX resolves `GROX_VESSEL_ROOT` first, then current-checkout ancestry, then editable-source ancestry. A non-editable installed CLI may operate from a valid GroX checkout or with `GROX_VESSEL_ROOT` set; outside a bound Vessel it refuses to construct an empty company.
 
-## Persistence model
+## Persistence and recovery
 
 GroX separates continuity into three planes:
 
-1. **Cognitive continuity:** the Space Exploration project reconstitutes GorXu and project context.
-2. **Vessel source:** this GitHub repository is the durable source body.
-3. **Operational state:** private runtime state travels through verified `.groxstate` snapshots and is never committed publicly.
+1. **Cognitive continuity:** the current project/session layer reconstitutes GorXu and active cognitive context.
+2. **Vessel source:** this repository is the durable source body.
+3. **Operational state:** private SQLite state and `.groxstate` archives preserve Missions, Orders, Evidence, Crew state, memory, performance, graphs, evaluation, exceptions, and recovery state outside public Git.
 
-A sandbox or host is replaceable compute, not the permanent Vessel.
+A sandbox, runner, or host is replaceable compute, not the permanent Vessel.
 
-## Documentation map
+### Reconstitution rule
 
-### Authority and architecture
+A fresh or uncertain host may resume GroX only after source materialization, private-state verification or restoration when needed, integrity gates, and GorXu reconstitution. Recovery scope increases when evidence is missing or unsafe:
 
-- `AI_INSTRUCTIONS.md` — repository authority and builder constraints.
-- `docs/architecture/ARCHITECTURE.md` — command, runtime, Crew, memory, tool, and recovery architecture.
-- `docs/architecture/PERSISTENCE_ARCHITECTURE.md` — three-plane persistence and reconstitution protocol.
-- `docs/specification/PRINCIPLES.md` — durable GroX operating principles.
-- `docs/specification/MISSION_ORDER.md` — bounded Crew authority contract.
-- `docs/specification/MISSION_GRAPH.md` — durable multi-Crew orchestration contract.
+- **FAST** requires positive mandatory health evidence and clean source state.
+- **TARGETED** is limited to bounded noncritical WARN/UNKNOWN conditions after all FULL triggers are excluded.
+- **FULL** is required for fresh hosts, source changes, critical failures, non-PASS recovery readiness, unsafe in-flight state, dirty source, persistence warnings/failures, or missing/non-PASS mandatory evidence.
 
-### Qualified capability specifications
+Failure or ambiguity never grants additional authority.
 
-- `docs/specification/COGNITIVE_PILOT.md` — A1 cognition boundary.
-- `docs/specification/LIVING_COMPANY_INTELLIGENCE.md` — A3 memory, performance, and routing intelligence.
-- `docs/specification/DURABLE_OPERATIONS.md` — A4 recovery and executive exception loop.
-- `docs/specification/GOVERNED_CAPABILITIES.md` — A5 Tool Gateway and governed capability expansion.
-- `docs/specification/ORCHESTRATION_EVALUATION.md` — A6 evaluation and non-self-activating improvement proposals.
+See [`docs/architecture/PERSISTENCE_ARCHITECTURE.md`](docs/architecture/PERSISTENCE_ARCHITECTURE.md) and the current [`Roadmap`](docs/stewardship/ROADMAP.md).
 
-### Stewardship and history
+## Repository map
 
-- `docs/stewardship/APEX_ORCHESTRATOR_PLAN.md` — A1–A7 qualification contract and regression boundary.
-- `docs/stewardship/ROADMAP.md` — current post-Apex operating posture and future-evolution rules.
-- `docs/stewardship/progress-tracker.md` — canonical project-state tracker and qualification evidence.
-- `docs/stewardship/CREW_ROSTER.md` — current 82-Crew company state.
-- `docs/stewardship/SANDBOX_COMMISSIONING.md` — historical first-Vessel commissioning record.
-- `docs/history/ships-log/` — append-only milestone history; prior entries retain the state that was true when recorded.
+```text
+.
+├── README.md                     # public entry point
+├── AI_INSTRUCTIONS.md            # repository authority and builder constraints
+├── .github/workflows/ci.yml      # protected five-gate CI
+├── assets/                       # public visual assets
+├── configs/                      # Vessel configuration and persistence bindings
+├── docker/                       # governed container support
+├── docs/                         # architecture, specification, stewardship, history
+├── policy/                       # GroX-native policy and authority controls
+├── scripts/                      # validation, experiments, mutation and maintenance tools
+├── src/                          # GroX runtime implementation
+├── tests/                        # unit, integration, contract, experiment and mutation evidence
+└── pyproject.toml                # package and CLI definition
+```
 
-## Repository authority
+### Documentation map
 
-When repository documents conflict, follow the hierarchy in `AI_INSTRUCTIONS.md`. Current evidence and implementation truth override stale descriptive text, while historical records remain historical rather than being rewritten to look current.
+| If you want to understand... | Start here |
+|---|---|
+| repository authority and builder constraints | [`AI_INSTRUCTIONS.md`](AI_INSTRUCTIONS.md) |
+| command and runtime architecture | [`docs/architecture/ARCHITECTURE.md`](docs/architecture/ARCHITECTURE.md) |
+| persistence and reconstitution | [`docs/architecture/PERSISTENCE_ARCHITECTURE.md`](docs/architecture/PERSISTENCE_ARCHITECTURE.md) |
+| durable operating principles | [`docs/specification/PRINCIPLES.md`](docs/specification/PRINCIPLES.md) |
+| bounded Crew authority | [`docs/specification/MISSION_ORDER.md`](docs/specification/MISSION_ORDER.md) |
+| Mission Graph execution | [`docs/specification/MISSION_GRAPH.md`](docs/specification/MISSION_GRAPH.md) |
+| current Vessel status | [`docs/stewardship/progress-tracker.md`](docs/stewardship/progress-tracker.md) |
+| current strategic direction | [`docs/stewardship/ROADMAP.md`](docs/stewardship/ROADMAP.md) |
+| Apex regression boundary | [`docs/stewardship/APEX_ORCHESTRATOR_PLAN.md`](docs/stewardship/APEX_ORCHESTRATOR_PLAN.md) |
+| post-Apex evolution program | [`docs/stewardship/POST_APEX_EVOLUTION_PROGRAM_001.md`](docs/stewardship/POST_APEX_EVOLUTION_PROGRAM_001.md) |
+| current Standing Crew | [`docs/stewardship/CREW_ROSTER.md`](docs/stewardship/CREW_ROSTER.md) |
+| historical milestones | [`docs/history/ships-log/`](docs/history/ships-log/) |
+
+## Governance and evidence
+
+GroX distinguishes authority, implementation, evidence, verification, recovery, and release decisions rather than treating code existence as proof of operational qualification.
+
+### Authority hierarchy
+
+When repository sources disagree, use the hierarchy defined in [`AI_INSTRUCTIONS.md`](AI_INSTRUCTIONS.md):
+
+1. Commander directives;
+2. `AI_INSTRUCTIONS.md`;
+3. canonical architecture and specification documents;
+4. stewardship documents;
+5. current code and tests;
+6. builder judgment.
+
+Higher authority wins when instructions conflict. Historical records remain historical rather than being rewritten to appear current.
+
+### Evidence discipline
+
+- implementation is not qualification;
+- a green CI run proves the checks it actually executed, not a broader claim;
+- controlled experiments remain distinct from integrated operational evidence;
+- red evidence is preserved when it reveals a real weakness or ambiguity;
+- consequential changes must preserve Commander sovereignty, GorXu's sole-orchestrator role, bounded Mission Orders, verifier independence, evidence integrity, recovery, and source/state compatibility;
+- private SQLite state, `.groxstate` archives, and secrets remain outside public Git by design.
+
+The README is an entry point. It does not outrank current repository authority, implementation evidence, the Progress Tracker, or the Roadmap.
+
+## Roadmap
+
+The Apex critical path is complete. GroX is now evolving through **Post-Apex Operational Evolution Program 001** without introducing a predeclared A8.
+
+Completed program stages include:
+
+- external capability intake convention;
+- continuous critical-detector mutation proving;
+- native read-only Vessel health;
+- tiered FAST/TARGETED/FULL reconstitution planning;
+- controlled HOT/WARM/COLD context policy experiment.
+
+The next approved stage is **#28 A6 longitudinal operational drift analysis**, followed by mission-to-source provenance research and integrated operational qualification of the changed surfaces. Completion of an individual stage does not imply a version bump, release tag, new Apex stage, or authority expansion.
+
+The Commander retains the release decision.
+
+See the canonical [`Roadmap`](docs/stewardship/ROADMAP.md) for current sequencing and evidence boundaries.
+
+---
+
+<div align="center">
+
+**Persistent continuity. Bounded authority. Evidence-bearing execution.**
+
+[Back to top](#readme-top)
+
+</div>


### PR DESCRIPTION
## What changed

Reworked the GroX public README into a higher-signal entry point using the information architecture that proved effective on TEO, while preserving GroX-native architecture, terminology, qualification state, and evidence boundaries.

### Improvements

- keeps the new high-resolution GroX banner
- adds centered project identity, CI/release badges, and direct navigation
- adds a collapsible table of contents
- introduces a concise About / Why GroX entry point
- makes the canonical command spine immediately visible
- explains how Commander intent flows through GorXu, Missions, Mission Orders, Crew, evidence, and verification
- separates what GroX owns from what it deliberately does not own
- replaces the long top-level operational inventory with a compact current-state table and progressive evidence disclosure
- surfaces Post-Apex Operational Evolution Program 001 and the current next stage, #28 A6 longitudinal operational drift analysis
- adds a clearer Quick Start, persistence/reconstitution summary, repository map, documentation map, governance/evidence section, and roadmap summary
- preserves the distinction between controlled experiments and integrated operational proof
- preserves Apex as a regression boundary rather than inherited authority

## Scope

README-only documentation change. No Commander/GorXu/Crew authority, Mission Order semantics, Mission Graph behavior, routing, persistence schema, Tool Gateway grants, cognition, package version, release tag, Apex stage, or runtime behavior is changed.

## Validation intent

GroX's five required CI gates should validate the exact PR head. Any repository-truth or regression failure is evidence to fix rather than bypass.