### PR TITLE
Remove obsolete Crew terminology from current tree

### DIFF
--- a/tests/contracts/test_current_crew_terminology.py
+++ b/tests/contracts/test_current_crew_terminology.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+FORBIDDEN = ("systems-" + "architect", "ret" + "ired")
+
+
+class CurrentCrewTerminologyContract(unittest.TestCase):
+    def test_tracked_current_tree_contains_no_obsolete_crew_terms(self) -> None:
+        proc = subprocess.run(
+            ["git", "ls-files", "-z"],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+        )
+        violations: list[str] = []
+        for raw_path in proc.stdout.split(b"\0"):
+            if not raw_path:
+                continue
+            rel = raw_path.decode("utf-8")
+            path = ROOT / rel
+            try:
+                text = path.read_text(encoding="utf-8")
+            except (UnicodeDecodeError, OSError):
+                continue
+            for token in FORBIDDEN:
+                if token in text:
+                    violations.append(f"{rel}: {token}")
+        self.assertFalse(
+            violations,
+            "obsolete Crew terminology remains in the current tracked tree:\n"
+            + "\n".join(sorted(violations)),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Mission

Resolve #47 by removing obsolete non-standing Crew terminology from the current tracked GroX tree while preserving the generic source-defined Standing Crew purge rule and immutable Git history.

## First step

This draft intentionally adds a permanent tracked-tree contract before cleanup. The contract scans Git-tracked UTF-8 text and rejects the obsolete identity token and legacy status term without embedding either literal in the contract itself.

The first CI result is expected to provide bounded red evidence identifying the remaining current-tree locations. Those locations will then be repaired narrowly; no command, Crew membership, routing, capability, persistence, Tool Gateway, or authority behavior is authorized to change.

## Boundary

Historical Git commits are not rewritten. The final current tree must pass the terminology contract and all five protected CI gates before this PR can leave draft state.