### PR TITLE
Make Mission outcomes truthful for scan-only execution

### DIFF
--- a/src/grox/pilot.py
+++ b/src/grox/pilot.py
@@ -117,12 +117,18 @@ class PilotGorXu:
         operation=str(order.parameters.get('operation') or '')
         verification_scope='bounded_execution_evidence' if verification else None
         if result.status!='completed':
+            rollback=next((ev.content for ev in reversed(result.evidence) if ev.kind=='mutation_rollback'),None)
+            rollback_completed=isinstance(rollback,dict) and rollback.get('status')=='rolled_back'
+            exception_type=str((result.exception or {}).get('type') or '')
+            mutation_observed='mutation' in kinds
+            mutation_unresolved=(mutation_observed and not rollback_completed) or exception_type=='mutation_state_diverged'
+            effect='mutation_rolled_back' if mutation_observed and rollback_completed else ('mutation_state_unresolved' if mutation_unresolved else 'exception')
             return {
                 'execution':result.status,
-                'effect':'exception',
+                'effect':effect,
                 'objective':'not_delivered',
-                'mutation':False,
-                'next_authority':None,
+                'mutation':mutation_unresolved,
+                'next_authority':'pilot_recovery' if mutation_unresolved else None,
                 'verification_scope':verification_scope,
             }
         if order.mode is MissionMode.execute and 'inventory' in kinds:

--- a/src/grox/pilot.py
+++ b/src/grox/pilot.py
@@ -112,6 +112,56 @@ class PilotGorXu:
         self.store.add_evidence(mission_id,'GORXU-FAULT',Evidence('unexpected_defect',payload))
         return payload
 
+    def _mission_outcome(self, order:MissionOrder, result:TourResult, verification:dict|None)->dict[str,Any]:
+        kinds={ev.kind for ev in result.evidence}
+        operation=str(order.parameters.get('operation') or '')
+        verification_scope='bounded_execution_evidence' if verification else None
+        if result.status!='completed':
+            return {
+                'execution':result.status,
+                'effect':'exception',
+                'objective':'not_delivered',
+                'mutation':False,
+                'next_authority':None,
+                'verification_scope':verification_scope,
+            }
+        if order.mode is MissionMode.execute and 'inventory' in kinds:
+            return {
+                'execution':'completed',
+                'effect':'scan_only',
+                'objective':'not_delivered',
+                'mutation':False,
+                'next_authority':'explicit_operation_or_repair',
+                'verification_scope':verification_scope,
+            }
+        if order.mode is MissionMode.repair and operation=='write_text':
+            mutated='mutation' in kinds
+            return {
+                'execution':'completed',
+                'effect':'mutation_applied' if mutated else 'mutation_verified',
+                'objective':'satisfied',
+                'mutation':mutated,
+                'next_authority':None,
+                'verification_scope':verification_scope,
+            }
+        if order.mode in {MissionMode.inspect,MissionMode.verify}:
+            return {
+                'execution':'completed',
+                'effect':'inspection',
+                'objective':'not_proven',
+                'mutation':False,
+                'next_authority':None,
+                'verification_scope':verification_scope,
+            }
+        return {
+            'execution':'completed',
+            'effect':operation or 'governed_execute',
+            'objective':'not_proven',
+            'mutation':False,
+            'next_authority':None,
+            'verification_scope':verification_scope,
+        }
+
     def command(self, directive:str, *, mode:MissionMode|None=None, risk:RiskClass|None=None, crew_id:str|None=None, scope:str='.', parameters:dict|None=None)->dict:
         brief,cognition_error,cognition_usage=self._interpret(directive)
         mode=self._reconcile_mode(directive,mode,brief)
@@ -172,13 +222,27 @@ class PilotGorXu:
                 crew_id=crew.crew_id,mission_id=mission_id,order_id=order.order_id,task_class=order.parameters['_task_class'],
                 result=result,latency_ms=elapsed_ms,risk=risk,verified=verification['ok'] if verification else None,
             )
+            outcome=self._mission_outcome(order,result,verification)
+            self.store.add_evidence(mission_id,order.order_id,Evidence('mission_outcome',outcome))
             summary=f"GorXu: {result.summary}"
             if brief: summary += f" | Cognitive strategy: {brief.recommended_option or 'structured interpretation'} ({brief.confidence:.2f})"
             if cognition_error: summary += " | Cognitive provider degraded; deterministic fallback used"
             if result.exception: summary += f" | Exception returned to Pilot: {result.exception['type']}"
-            if verification: summary += f" | Verification: {'PASS' if verification['ok'] else 'FAIL'} by {verification['verifier']}"
-            self.store.update_mission(mission_id,'completed' if result.status=='completed' else 'needs_pilot_decision',summary)
-            return {'mission_id':mission_id,'mode':mode.value,'risk':risk.value,'crew':crew.crew_id,'status':result.status,'summary':summary,'verification':verification,'exception':result.exception,'cognition':brief.to_dict() if brief else None,'cognition_error':cognition_error}
+            summary += (
+                f" | Outcome: effect={outcome['effect']}; objective={outcome['objective']}; "
+                f"mutation={'yes' if outcome['mutation'] else 'no'}"
+            )
+            if outcome['next_authority']:
+                summary += f"; next_authority={outcome['next_authority']}"
+            if verification:
+                scope_note='; bounded execution evidence only' if outcome['objective']!='satisfied' else ''
+                summary += f" | Verification: {'PASS' if verification['ok'] else 'FAIL'} by {verification['verifier']}{scope_note}"
+            mission_status='scan_only' if result.status=='completed' and outcome['effect']=='scan_only' else ('completed' if result.status=='completed' else 'needs_pilot_decision')
+            self.store.update_mission(mission_id,mission_status,summary)
+            public_status=mission_status if mission_status=='scan_only' else result.status
+            return {'mission_id':mission_id,'mode':mode.value,'risk':risk.value,'crew':crew.crew_id,'status':public_status,'execution_status':result.status,
+                    'mission_status':mission_status,'outcome':outcome,'summary':summary,'verification':verification,'exception':result.exception,
+                    'cognition':brief.to_dict() if brief else None,'cognition_error':cognition_error}
         except LookupError as exc:
             summary=f"GorXu bounded routing exception: {exc}"
             self.store.add_graph_event(

--- a/tests/integration/test_mission_outcome_failure_truthfulness.py
+++ b/tests/integration/test_mission_outcome_failure_truthfulness.py
@@ -1,0 +1,50 @@
+import unittest
+
+from grox.contracts import Evidence, MissionMode, TourResult
+from tests._support import temp_vessel
+
+
+class FailedRollbackExecutor:
+    def execute(self, order):
+        return TourResult(
+            order.order_id,
+            order.assigned_crew,
+            "exception",
+            "Repair verification failed and rollback could not safely reconcile target state",
+            [
+                Evidence("mutation", {"operation": "write_text", "path": "docs/x.txt"}),
+                Evidence("mutation_rollback", {"status": "failed"}),
+            ],
+            {
+                "type": "mutation_state_diverged",
+                "irreversible": True,
+                "recommendation": "Return to GorXu; do not overwrite divergent state",
+            },
+        )
+
+
+class MissionOutcomeFailureTruthfulnessTests(unittest.TestCase):
+    def test_failed_repair_with_unresolved_mutation_reports_mutation_present(self):
+        td, root, pilot = temp_vessel()
+        try:
+            pilot.executor = FailedRollbackExecutor()
+            result = pilot.command(
+                "Repair docs/x.txt",
+                mode=MissionMode.repair,
+                scope="docs/x.txt",
+                parameters={"operation": "write_text", "path": "docs/x.txt", "content": "x"},
+            )
+            self.assertEqual(result["status"], "exception")
+            self.assertEqual(result["mission_status"], "needs_pilot_decision")
+            self.assertEqual(result["outcome"]["effect"], "mutation_state_unresolved")
+            self.assertEqual(result["outcome"]["objective"], "not_delivered")
+            self.assertTrue(result["outcome"]["mutation"])
+            self.assertEqual(result["outcome"]["next_authority"], "pilot_recovery")
+            self.assertIn("mutation=yes", result["summary"])
+            self.assertIn("next_authority=pilot_recovery", result["summary"])
+        finally:
+            td.cleanup()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/integration/test_mission_outcome_failure_truthfulness.py
+++ b/tests/integration/test_mission_outcome_failure_truthfulness.py
@@ -4,21 +4,24 @@ from grox.contracts import Evidence, MissionMode, TourResult
 from tests._support import temp_vessel
 
 
-class FailedRollbackExecutor:
+class MutationExceptionExecutor:
+    def __init__(self, rollback_status):
+        self.rollback_status = rollback_status
+
     def execute(self, order):
         return TourResult(
             order.order_id,
             order.assigned_crew,
             "exception",
-            "Repair verification failed and rollback could not safely reconcile target state",
+            "Repair verification failed after mutation",
             [
                 Evidence("mutation", {"operation": "write_text", "path": "docs/x.txt"}),
-                Evidence("mutation_rollback", {"status": "failed"}),
+                Evidence("mutation_rollback", {"status": self.rollback_status}),
             ],
             {
-                "type": "mutation_state_diverged",
-                "irreversible": True,
-                "recommendation": "Return to GorXu; do not overwrite divergent state",
+                "type": "mutation_state_diverged" if self.rollback_status == "failed" else "post_repair_test_failure",
+                "irreversible": self.rollback_status == "failed",
+                "recommendation": "Return to GorXu",
             },
         )
 
@@ -27,7 +30,7 @@ class MissionOutcomeFailureTruthfulnessTests(unittest.TestCase):
     def test_failed_repair_with_unresolved_mutation_reports_mutation_present(self):
         td, root, pilot = temp_vessel()
         try:
-            pilot.executor = FailedRollbackExecutor()
+            pilot.executor = MutationExceptionExecutor("failed")
             result = pilot.command(
                 "Repair docs/x.txt",
                 mode=MissionMode.repair,
@@ -42,6 +45,24 @@ class MissionOutcomeFailureTruthfulnessTests(unittest.TestCase):
             self.assertEqual(result["outcome"]["next_authority"], "pilot_recovery")
             self.assertIn("mutation=yes", result["summary"])
             self.assertIn("next_authority=pilot_recovery", result["summary"])
+        finally:
+            td.cleanup()
+
+    def test_failed_repair_with_completed_rollback_reports_no_remaining_mutation(self):
+        td, root, pilot = temp_vessel()
+        try:
+            pilot.executor = MutationExceptionExecutor("rolled_back")
+            result = pilot.command(
+                "Repair docs/x.txt",
+                mode=MissionMode.repair,
+                scope="docs/x.txt",
+                parameters={"operation": "write_text", "path": "docs/x.txt", "content": "x"},
+            )
+            self.assertEqual(result["status"], "exception")
+            self.assertEqual(result["outcome"]["effect"], "mutation_rolled_back")
+            self.assertFalse(result["outcome"]["mutation"])
+            self.assertIsNone(result["outcome"]["next_authority"])
+            self.assertIn("mutation=no", result["summary"])
         finally:
             td.cleanup()
 

--- a/tests/integration/test_pilot.py
+++ b/tests/integration/test_pilot.py
@@ -16,7 +16,32 @@ class PilotTest(unittest.TestCase):
         try:
             result = p.command("Inspect architecture and report", mode=MissionMode.inspect)
             self.assertEqual(result["status"], "completed")
+            self.assertEqual(result["execution_status"], "completed")
+            self.assertEqual(result["mission_status"], "completed")
+            self.assertEqual(result["outcome"]["effect"], "inspection")
+            self.assertEqual(result["outcome"]["objective"], "not_proven")
             self.assertEqual(result["crew"], "test-architecture-specialist")
+        finally:
+            td.cleanup()
+
+    def test_generic_execute_scan_is_not_reported_as_objective_delivery(self):
+        td, root, p = temp_vessel()
+        try:
+            result = p.command("Build the ship and pilot it. Make me a working AI agent company.")
+            self.assertEqual(result["status"], "scan_only")
+            self.assertEqual(result["execution_status"], "completed")
+            self.assertEqual(result["mission_status"], "scan_only")
+            self.assertEqual(result["outcome"]["effect"], "scan_only")
+            self.assertEqual(result["outcome"]["objective"], "not_delivered")
+            self.assertFalse(result["outcome"]["mutation"])
+            self.assertEqual(result["outcome"]["next_authority"], "explicit_operation_or_repair")
+            self.assertIn("objective=not_delivered", result["summary"])
+            mission = p.store.mission(result["mission_id"])
+            self.assertEqual(mission["mission"]["status"], "scan_only")
+            outcomes = [e for e in mission["evidence"] if e["kind"] == "mission_outcome"]
+            self.assertEqual(len(outcomes), 1)
+            persisted = json.loads(outcomes[0]["content"])
+            self.assertEqual(persisted, result["outcome"])
         finally:
             td.cleanup()
 
@@ -25,9 +50,19 @@ class PilotTest(unittest.TestCase):
         try:
             result = p.repair_write("docs/x.txt", "hello")
             self.assertEqual(result["status"], "completed")
+            self.assertEqual(result["execution_status"], "completed")
+            self.assertEqual(result["mission_status"], "completed")
+            self.assertEqual(result["outcome"]["effect"], "mutation_applied")
+            self.assertEqual(result["outcome"]["objective"], "satisfied")
+            self.assertTrue(result["outcome"]["mutation"])
+            self.assertEqual(result["outcome"]["verification_scope"], "bounded_execution_evidence")
             self.assertTrue(result["verification"]["ok"])
             self.assertNotEqual(result["crew"], result["verification"]["verifier"])
             self.assertEqual((root / "docs/x.txt").read_text(), "hello")
+            mission = p.store.mission(result["mission_id"])
+            outcomes = [e for e in mission["evidence"] if e["kind"] == "mission_outcome"]
+            self.assertEqual(len(outcomes), 1)
+            self.assertEqual(json.loads(outcomes[0]["content"]), result["outcome"])
         finally:
             td.cleanup()
 
@@ -41,10 +76,24 @@ class PilotTest(unittest.TestCase):
                 scope="docs/implicit.txt",
             )
             self.assertEqual(result["mode"], "execute")
+            self.assertEqual(result["status"], "scan_only")
+            self.assertEqual(result["execution_status"], "completed")
+            self.assertEqual(result["mission_status"], "scan_only")
+            self.assertEqual(result["outcome"]["effect"], "scan_only")
+            self.assertEqual(result["outcome"]["objective"], "not_delivered")
+            self.assertFalse(result["outcome"]["mutation"])
+            self.assertEqual(result["outcome"]["next_authority"], "explicit_operation_or_repair")
+            self.assertEqual(result["outcome"]["verification_scope"], "bounded_execution_evidence")
+            self.assertTrue(result["verification"]["ok"])
+            self.assertIn("bounded execution evidence only", result["summary"])
             self.assertFalse(target.exists())
             mission = p.store.mission(result["mission_id"])
+            self.assertEqual(mission["mission"]["status"], "scan_only")
             payload = json.loads(mission["orders"][0]["payload"])
             self.assertNotIn("fs_write", payload["allowed_actions"])
+            outcomes = [e for e in mission["evidence"] if e["kind"] == "mission_outcome"]
+            self.assertEqual(len(outcomes), 1)
+            self.assertEqual(json.loads(outcomes[0]["content"]), result["outcome"])
         finally:
             td.cleanup()
 


### PR DESCRIPTION
Closes #70.

## What changed

- adds a GorXu-owned Mission outcome classification for single-Mission execution;
- separates `execution_status` from Commander-facing Mission delivery status;
- returns and persists a `mission_outcome` contract with `execution`, `effect`, `objective`, `mutation`, `next_authority`, and verification scope;
- reports generic Execute fallback work as `status: scan_only` while retaining `execution_status: completed`;
- stores scan-only Missions as `scan_only` rather than plain `completed`;
- makes verification wording explicit when verification proves bounded execution evidence but not objective delivery;
- preserves supported `repair-write` as `completed` with `mutation_applied`, `objective: satisfied`, and independent verification;
- conservatively reports failed Repair rollback/divergent mutation state as `mutation_state_unresolved`, `mutation: true`, requiring Pilot recovery, while a completed rollback reports no remaining mutation.

## Root cause

The executor correctly completed a bounded repository inventory when no governed Execute operation existed, but Pilot synthesis reused the Tour lifecycle status as the Commander-facing Mission outcome. This conflated successful bounded execution with delivery of the requested objective.

Independent review also found that a naive exception classification would have reported `mutation: false` even when a Repair mutation remained unresolved after rollback failure. The branch now derives that state from mutation/rollback evidence and `mutation_state_diverged` exceptions instead of assuming all failed Missions are non-mutating.

## Authority boundary

No authority is widened. Execute remains non-mutating, `fs_write` remains forbidden outside explicit Repair, natural-language Repair-like wording still cannot grant mutation authority, and Mission Graph behavior is unchanged.

## Validation

Integration regressions cover:

1. naive `Build the ship and pilot it` intent → `scan_only`, objective not delivered, no mutation;
2. `Fix and write` under Execute → `scan_only`, no `fs_write`, verification explicitly scoped to bounded execution evidence;
3. supported `repair-write` → completed mutation, objective satisfied, independent verifier preserved;
4. existing Inspect behavior remains completed while objective proof is not overstated;
5. failed Repair with failed rollback/divergent state → unresolved mutation is surfaced and returned to Pilot recovery;
6. failed Repair with completed rollback → no remaining mutation is reported.

Canonical GitHub CI on the exact final head is the merge qualification authority.