### PR TITLE
Activate bounded selective deep-craft Crew cognition

### DIFF
--- a/AI_INSTRUCTIONS.md
+++ b/AI_INSTRUCTIONS.md
@@ -37,6 +37,7 @@ Pilot GorXu is the primary orchestrator and second-in-command. Mission Control i
 - Crew craft, memory, cognitive-provider output, confidence, and prior performance are competence/advisory context only. None may create eligibility, capability, Repair authority, risk reduction, scope expansion, routing authority, or verifier independence.
 - Selective Crew craft context must remain bounded and attributable. Do not inject complete deep craft cards per summon by default, and do not omit mandatory safety/operational-binding context merely to fit optional task detail.
 - Provider-driven Crew actions must traverse the existing sealed Mission Order and Tool Gateway. The first bounded Crew-cognition seam is Inspect-only and read/test-only; Verify, Repair, and Execute must not silently inherit model-backed Crew cognition.
+- Craft-selection and Crew-cognition bookkeeping must not improve Crew performance or routing scores merely by adding evidence kinds. Only calibrated operational evidence may affect evidence-quality history.
 - Crew encountering blockers, safer alternatives, better methods, missing capability, or elevated risk must stop the affected mutation and report to GorXu.
 - GorXu should resolve ordinary and reversible issues using Mission Control and relevant Crew. Escalate to the Commander only for critical, irreversible, or material intent-changing decisions.
 - Independent verification must remain independent from the executor when required by GroX policy.

--- a/AI_INSTRUCTIONS.md
+++ b/AI_INSTRUCTIONS.md
@@ -24,7 +24,7 @@ Higher authority wins when instructions conflict.
 
 **Commander → Pilot GorXu → Divisions → Standing Crew**
 
-Pilot GorXu is the primary orchestrator and second-in-command. Mission Control is a native GroX policy/advisory service used by GorXu; it is not a command layer. No Crew member, Division, verifier, tool, scheduler, or external system may become a parallel orchestrator.
+Pilot GorXu is the primary orchestrator and second-in-command. Mission Control is a native GroX policy/advisory service used by GorXu; it is not a command layer. No Crew member, Division, verifier, tool, scheduler, cognitive provider, or external system may become a parallel orchestrator.
 
 ## Hard constraints
 
@@ -34,6 +34,9 @@ Pilot GorXu is the primary orchestrator and second-in-command. Mission Control i
 - Do not conflate competence with authority. Knowing how to perform an action does not grant permission to perform it.
 - Keep inspection and repair authority separate.
 - Do not conflate successful bounded execution with delivery of the Commander objective. Mission synthesis must state actual effect, objective state, mutation state, and verification scope truthfully.
+- Crew craft, memory, cognitive-provider output, confidence, and prior performance are competence/advisory context only. None may create eligibility, capability, Repair authority, risk reduction, scope expansion, routing authority, or verifier independence.
+- Selective Crew craft context must remain bounded and attributable. Do not inject complete deep craft cards per summon by default, and do not omit mandatory safety/operational-binding context merely to fit optional task detail.
+- Provider-driven Crew actions must traverse the existing sealed Mission Order and Tool Gateway. The first bounded Crew-cognition seam is Inspect-only and read/test-only; Verify, Repair, and Execute must not silently inherit model-backed Crew cognition.
 - Crew encountering blockers, safer alternatives, better methods, missing capability, or elevated risk must stop the affected mutation and report to GorXu.
 - GorXu should resolve ordinary and reversible issues using Mission Control and relevant Crew. Escalate to the Commander only for critical, irreversible, or material intent-changing decisions.
 - Independent verification must remain independent from the executor when required by GroX policy.
@@ -62,6 +65,7 @@ Pilot GorXu is the primary orchestrator and second-in-command. Mission Control i
 - Record major architectural milestones in the Ship's Log.
 - Treat implementation claims as unverified until source and tests are inspected.
 - Preserve approved architecture when synchronizing or recovering runtime state; do not replace richer canonical doctrine with bootstrap summaries.
+- Distinguish controlled/fake-provider CI from live model-backed operation. A provider-neutral seam is not a live-provider qualification claim.
 
 ## Builder objective
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -48,10 +48,10 @@ Authority may narrow as it travels downward. It may not widen without a new deci
 1. **Commander Seat:** CLI/bridge for directives, status, intervention, and review.
 2. **Pilot GorXu:** interprets intent, plans, consults Mission Control, selects Crew, issues Orders, and synthesizes outcomes.
 3. **Mission Control:** risk, authority, routing, verification, evidence, and advisory policy.
-4. **Standing Crew:** durable organizational identity with fresh mission-specific tours, bounded selected craft/memory context, and optional governed read-only cognition when separately configured.
+4. **Standing Crew:** durable organizational identity with fresh mission-specific tours, bounded relevant memory, selective deep craft on Inspect tours, and optional governed read-only cognition when separately configured.
 5. **Tool Gateway:** deny-wins capability enforcement and host/Vessel confinement.
 6. **Mission Store:** durable Mission, Order, Evidence, Crew, memory, and performance state.
-7. **Living Company Intelligence:** advisory memory retrieval, selective specialist craft context, and experienced eligible-Crew ranking under GorXu.
+7. **Living Company Intelligence:** advisory memory retrieval, Inspect-only selective specialist craft context, and experienced eligible-Crew ranking under GorXu.
 8. **Durable Operations:** private graph-run/checkpoint/exception/mutation ledger for safe resume and compensation under GorXu.
 9. **Executive Exception Loop:** deterministic classification and bounded consultation/replan policy under GorXu.
 10. **Verification:** independent verification path where policy requires it.
@@ -63,7 +63,7 @@ Selective Crew cognition is not another runtime command layer. It is an optional
 
 Crew are logically persistent organizational identities with durable dossiers, competencies, procedures, history, memory, and canonical specialist craft. They need not remain as live model processes while asleep.
 
-Each wake creates a fresh tour context containing only what is needed for the current Mission plus relevant retrieved memory and bounded Mission-relevant craft. The complete historical memory store and complete deep craft card are not injected by default. This preserves continuity and expertise without allowing old working context or million-character craft libraries to accumulate indiscriminately.
+Each wake creates a fresh tour context containing only what is needed for the current Mission plus relevant retrieved memory. A bounded Inspect tour may additionally receive Mission-relevant craft sections from that Crew member's canonical craft card. Verify, Repair, and Execute do not carry unused deep craft in the first cognition seam. The complete historical memory store and complete deep craft card are never injected by default.
 
 Crew competence and Mission authority are separate:
 
@@ -109,15 +109,17 @@ The first bounded Crew cognition seam does not operate in Repair. Model or craft
 
 ## Selective craft and Crew cognition
 
-After Crew routing and before Mission Order sealing, Living Company Intelligence may attach bounded competence context for the assigned Standing Crew member.
+After Crew routing and before an **Inspect** Mission Order is sealed, Living Company Intelligence may attach bounded Mission-relevant craft for the assigned Standing Crew member. Other modes retain their existing task/memory context without selective deep craft.
 
 The selective-craft path:
 
 - reads only the assigned active Crew member's canonical craft card;
-- reserves context for `Purpose`, `Safety Boundaries`, and `GroX Operational Binding` when present;
-- selects additional Mission-relevant sections deterministically;
+- requires `Purpose`, `Safety Boundaries`, and `GroX Operational Binding` to fit **in full** when present;
+- fails closed rather than truncating mandatory safety/operational binding when the configured budget is insufficient;
+- selects additional Mission-relevant sections deterministically from the remaining budget;
 - defaults to at most **6 sections / 4,500 characters**;
 - records the full-card SHA-256, selected headings/size, source revision, and freshness policy;
+- emits explicit `craft_selection` evidence during Inspect execution;
 - never treats craft prose as authority;
 - never injects the complete deep card by default.
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -48,25 +48,29 @@ Authority may narrow as it travels downward. It may not widen without a new deci
 1. **Commander Seat:** CLI/bridge for directives, status, intervention, and review.
 2. **Pilot GorXu:** interprets intent, plans, consults Mission Control, selects Crew, issues Orders, and synthesizes outcomes.
 3. **Mission Control:** risk, authority, routing, verification, evidence, and advisory policy.
-4. **Standing Crew:** durable organizational identity with fresh mission-specific tours.
+4. **Standing Crew:** durable organizational identity with fresh mission-specific tours, bounded selected craft/memory context, and optional governed read-only cognition when separately configured.
 5. **Tool Gateway:** deny-wins capability enforcement and host/Vessel confinement.
 6. **Mission Store:** durable Mission, Order, Evidence, Crew, memory, and performance state.
-7. **Living Company Intelligence:** advisory memory retrieval and experienced eligible-Crew ranking under GorXu.
+7. **Living Company Intelligence:** advisory memory retrieval, selective specialist craft context, and experienced eligible-Crew ranking under GorXu.
 8. **Durable Operations:** private graph-run/checkpoint/exception/mutation ledger for safe resume and compensation under GorXu.
 9. **Executive Exception Loop:** deterministic classification and bounded consultation/replan policy under GorXu.
 10. **Verification:** independent verification path where policy requires it.
 11. **Persistence Manager:** private operational-state snapshots, integrity checking, and confirmation-gated restore.
 
+Selective Crew cognition is not another runtime command layer. It is an optional bounded working mode inside an already-issued Standing Crew Inspect tour and remains subordinate to the same Mission Order and Tool Gateway.
+
 ## Standing Crew model
 
-Crew are logically persistent organizational identities with durable dossiers, competencies, procedures, history, and memory. They need not remain as live model processes while asleep.
+Crew are logically persistent organizational identities with durable dossiers, competencies, procedures, history, memory, and canonical specialist craft. They need not remain as live model processes while asleep.
 
-Each wake creates a fresh tour context containing only what is needed for the current Mission plus relevant retrieved memory. This preserves continuity without allowing old working context to accumulate indefinitely.
+Each wake creates a fresh tour context containing only what is needed for the current Mission plus relevant retrieved memory and bounded Mission-relevant craft. The complete historical memory store and complete deep craft card are not injected by default. This preserves continuity and expertise without allowing old working context or million-character craft libraries to accumulate indiscriminately.
 
 Crew competence and Mission authority are separate:
 
 - Competence describes what a Crew member knows how to do.
 - Mission authority describes what that Crew member may do now.
+
+Craft, memory, provider output, confidence, and prior performance belong to the competence/advisory side of that boundary. They cannot manufacture authority.
 
 ## Mission Control
 
@@ -93,17 +97,50 @@ Inspection and mutation are separate modes.
 - no mutation authority unless explicitly required for a safe diagnostic and granted in the Mission Order;
 - findings return to GorXu.
 
+An optional provider-neutral Crew cognition seam may assist Inspect tours. It receives a sanitized copy of the issued Order plus bounded selected craft, bounded relevant memory, and observations produced through the existing Tool Gateway. The first bounded seam permits only `fs_list`, `fs_read`, and `test_run`; all requests remain subject to the sealed Order, Crew capability, scope, host policy, and Tool Gateway denial. The provider does not own tools directly.
+
 ### Repair
 
 - issued only after GorXu has accepted a repair path within delegated authority or the Commander has approved where required;
 - mutation is restricted to explicit capabilities, paths, systems, and stop conditions;
 - blockers, better methods, elevated risk, or scope changes return to GorXu before affected mutation continues.
 
+The first bounded Crew cognition seam does not operate in Repair. Model or craft output cannot create Repair authority.
+
+## Selective craft and Crew cognition
+
+After Crew routing and before Mission Order sealing, Living Company Intelligence may attach bounded competence context for the assigned Standing Crew member.
+
+The selective-craft path:
+
+- reads only the assigned active Crew member's canonical craft card;
+- reserves context for `Purpose`, `Safety Boundaries`, and `GroX Operational Binding` when present;
+- selects additional Mission-relevant sections deterministically;
+- defaults to at most **6 sections / 4,500 characters**;
+- records the full-card SHA-256, selected headings/size, source revision, and freshness policy;
+- never treats craft prose as authority;
+- never injects the complete deep card by default.
+
+When a Crew cognition provider is separately configured, the first governed cognitive seam is **Inspect-only**. It defaults to:
+
+- at most **4** cognitive steps;
+- at most **1** cognitive `test_run` per tour;
+- at most **8,000** characters in each bounded observation returned to cognition;
+- at most **4,000** characters in the final cognitive work product.
+
+Provider-facing Order, craft, memory, and observation values are copies. Provider-local mutation cannot alter the executor-owned context, sealed Order, or prior observation history. Governed observations remain attributable evidence even when the provider later fails. Persistent read-observation evidence retains path/count/hash metadata rather than copying raw file contents into the cognitive evidence record.
+
+A mutating action request or scope escape is denied and does not gain a broader fallback. Known recoverable provider/contract failures may degrade to the existing deterministic Inspect executor. Verify, Repair, and Execute remain on their existing deterministic paths in this first seam.
+
+Controlled fake-provider CI qualifies only the provider-neutral seam and its safety properties. It is **not** evidence that a live project/session or external model provider is operational for Crew cognition. Live provider activation requires separate operational evidence.
+
 ## Verification
 
 Verification is independent where policy requires it. The executor may provide self-checks, but self-checks are not independent verification.
 
 Verification should evaluate the evidence package, requested outcome, authority compliance, and actual resulting state.
+
+The first bounded Crew cognition seam does not run in Verify mode and therefore cannot become an alternate automatic verifier or satisfy verifier independence by itself.
 
 ## Mission outcome truthfulness
 
@@ -168,6 +205,8 @@ The A5-qualified Tool Gateway v2 exposes bounded filesystem/list/test operations
 
 A5 browser capture deliberately keeps network authority in the Gateway: approved HTML is fetched through `net_fetch`, then rendered offline while browser-originated HTTP(S) is blocked. MCP process definitions are host/Pilot registered rather than Crew supplied, and mutating MCP tools require a separate mutation action grant. Secret values remain memory-only and are not durable Mission data.
 
+The Crew cognition seam reuses this same Gateway. It does not add direct provider tool ownership, an alternate filesystem API, broader network access, or an MCP/desktop path.
+
 Unrestricted interactive desktop actuation, arbitrary third-party/networked MCP transports, runtime image pulls/builds, and optional external-agent delegation remain outside the A5-qualified boundary.
 
 ## Memory architecture
@@ -184,13 +223,15 @@ Memory must support provenance, relevance, consolidation, correction, and bounde
 
 The qualified Living Company implementation provides episodic retrieval plus durable semantic, procedural, and Vessel memory. Durable records require explicit provenance, confidence, scope, and keys; corrections supersede rather than silently rewrite prior active records; records can be deactivated for bounded forgetting. Retrieval is relevance-scored and capped by item/character budgets, with memory-plane diversity preserved where relevant.
 
-Living Company Intelligence also persists per-Crew/task-class performance observations and lets GorXu rank only otherwise-eligible Crew using competence, evidence quality, reliability, load, cost, latency, risk, and prior performance. Memory and performance remain advisory: they cannot grant capability, lower risk, authorize Repair, alter Commander intent, or bypass verifier independence. Autonomous memory consolidation is not yet implemented.
+Living Company Intelligence also persists per-Crew/task-class performance observations and lets GorXu rank only otherwise-eligible Crew using competence, evidence quality, reliability, load, cost, latency, risk, and prior performance. Memory, craft, cognition, and performance remain advisory: they cannot grant capability, lower risk, authorize Repair, alter Commander intent, self-route Crew, or bypass verifier independence. Autonomous memory consolidation is not yet implemented.
 
 ## Cognitive Pilot
 
 GorXu may use a provider-neutral reasoning layer for interpretation, uncertainty detection, strategy comparison, and Crew recommendation. Cognition is advisory to the Pilot and never becomes an authority source.
 
 Deterministic Mission Control and Tool Gateway policy remain capable of denying model proposals. A model may raise caution but cannot lower the risk floor or grant itself mutation authority.
+
+Pilot cognition and Crew cognition are distinct placements under the same authority doctrine. Pilot cognition advises GorXu before or during orchestration. Optional Crew cognition operates only inside an already-issued bounded Inspect tour. Neither placement can create authority, and external intelligence does not inherit command merely because a provider can reason.
 
 ## Recruitment and evolution
 

--- a/docs/specification/LIVING_COMPANY_INTELLIGENCE.md
+++ b/docs/specification/LIVING_COMPANY_INTELLIGENCE.md
@@ -10,7 +10,7 @@ Living Company Intelligence is a native advisory service under Pilot GorXu.
 
 **Commander → Pilot GorXu → Divisions → Standing Crew**
 
-The intelligence service may rank eligible Crew and retrieve relevant memory and craft context. It may not:
+The intelligence service may rank eligible Crew and retrieve relevant memory and, for bounded Inspect tours, selective craft context. It may not:
 
 - create a new command layer;
 - grant capabilities or mutation authority;
@@ -69,27 +69,28 @@ Historical performance may change the winner among otherwise eligible Crew. It c
 
 ## Context-isolated tours
 
-Every Mission Order remains a fresh bounded tour. Living Company Intelligence adds only pre-issuance competence context and attribution metadata:
+Every Mission Order remains a fresh bounded tour. Living Company Intelligence continues to add:
 
 - a stable task-class label;
 - a capped relevant-memory context;
-- a bounded selective specialist-craft context;
-- routing/context-selection evidence.
+- routing/context-selection metadata.
 
-The memory context remains bounded by item count and character budget. Specialist craft is selected only from the routed Standing Crew member's canonical craft card. The complete craft card is not injected by default.
+For **Inspect** tours only, Living Company Intelligence may also add bounded selective specialist craft before the Order is sealed. Verify, Repair, and Execute retain their existing memory/routing context without carrying unused deep craft.
 
 ### Selective specialist craft
 
-The post-Apex selective-craft path uses deterministic section selection after Crew routing and before Mission Order sealing.
+The post-Apex selective-craft path uses deterministic section selection after Crew routing and before an Inspect Mission Order is sealed.
 
 Default limits are:
 
 - at most **6** selected craft sections;
 - at most **4,500** selected craft characters.
 
-When present, `Purpose`, `Safety Boundaries`, and `GroX Operational Binding` receive reserved context budget before task-relevant optional sections. Remaining sections are selected by bounded lexical relevance with stable fallback fundamentals. The selected context carries the full-card SHA-256 plus source revision and freshness-policy metadata so the tour remains attributable to its canonical craft source.
+When present, `Purpose`, `Safety Boundaries`, and `GroX Operational Binding` must fit **in full** before optional task-relevant craft is selected. If the complete mandatory set cannot fit within the configured budget, selection fails closed rather than truncating safety/operational binding. Remaining sections are selected by bounded lexical relevance with stable fallback fundamentals.
 
-Craft context is competence context only. A craft card cannot add a capability, widen scope, lower risk, authorize Repair, override a forbidden action, self-route Crew, or satisfy verifier independence.
+The selected context carries the full-card SHA-256 plus source revision and freshness-policy metadata. Inspect execution emits explicit `craft_selection` evidence so selection remains attributable even when no cognition provider is configured.
+
+The complete craft card is never injected by default. Craft context is competence context only: a craft card cannot add a capability, widen scope, lower risk, authorize Repair, override a forbidden action, self-route Crew, or satisfy verifier independence.
 
 ## Bounded read-only Crew cognition
 
@@ -100,7 +101,7 @@ GroX exposes a provider-neutral Crew cognition seam for **Inspect** tours when a
 - the existing bounded relevant Crew memory;
 - observations returned only by governed read/test actions already allowed by that Order.
 
-The first bounded seam deliberately excludes Verify, Repair, and Execute. Those modes retain their existing deterministic execution paths.
+The first bounded seam deliberately excludes Verify, Repair, and Execute. Those modes retain their existing deterministic execution paths and do not receive selective deep craft through this seam.
 
 Within an Inspect tour, a cognitive Crew provider may request only:
 

--- a/docs/specification/LIVING_COMPANY_INTELLIGENCE.md
+++ b/docs/specification/LIVING_COMPANY_INTELLIGENCE.md
@@ -1,6 +1,6 @@
 # GroX Living Company Intelligence
 
-**Qualification status:** **A3 QUALIFIED** in GroX `v0.8.0`. Memory and experience remain advisory to GorXu and can never grant eligibility, authority, Repair permission, or verifier independence.
+**Qualification status:** **A3 QUALIFIED** in GroX `v0.8.0`. Memory, craft, experience, and Crew cognition remain advisory to GorXu and can never grant eligibility, authority, Repair permission, or verifier independence. Later protected-main evolution may strengthen these surfaces without creating a new Apex stage.
 
 A3 established the Standing Crew as an experienced organization without changing GroX command authority.
 
@@ -10,14 +10,14 @@ Living Company Intelligence is a native advisory service under Pilot GorXu.
 
 **Commander → Pilot GorXu → Divisions → Standing Crew**
 
-The intelligence service may rank eligible Crew and retrieve relevant memory. It may not:
+The intelligence service may rank eligible Crew and retrieve relevant memory and craft context. It may not:
 
 - create a new command layer;
 - grant capabilities or mutation authority;
 - lower Mission Control risk;
 - bypass verifier independence;
 - alter Commander intent;
-- make memory authoritative merely because it was previously stored.
+- make memory, craft prose, or provider output authoritative merely because it was supplied to a Crew tour.
 
 Crew competence and Mission authority remain hard eligibility gates. Experience affects ranking only after those gates pass.
 
@@ -69,13 +69,61 @@ Historical performance may change the winner among otherwise eligible Crew. It c
 
 ## Context-isolated tours
 
-Every Mission Order remains a fresh bounded tour. Living Company Intelligence adds only:
+Every Mission Order remains a fresh bounded tour. Living Company Intelligence adds only pre-issuance competence context and attribution metadata:
 
 - a stable task-class label;
 - a capped relevant-memory context;
-- routing-decision evidence.
+- a bounded selective specialist-craft context;
+- routing/context-selection evidence.
 
-The memory context is bounded by item count and character budget. This preserves continuity without accumulating prior working context indefinitely.
+The memory context remains bounded by item count and character budget. Specialist craft is selected only from the routed Standing Crew member's canonical craft card. The complete craft card is not injected by default.
+
+### Selective specialist craft
+
+The post-Apex selective-craft path uses deterministic section selection after Crew routing and before Mission Order sealing.
+
+Default limits are:
+
+- at most **6** selected craft sections;
+- at most **4,500** selected craft characters.
+
+When present, `Purpose`, `Safety Boundaries`, and `GroX Operational Binding` receive reserved context budget before task-relevant optional sections. Remaining sections are selected by bounded lexical relevance with stable fallback fundamentals. The selected context carries the full-card SHA-256 plus source revision and freshness-policy metadata so the tour remains attributable to its canonical craft source.
+
+Craft context is competence context only. A craft card cannot add a capability, widen scope, lower risk, authorize Repair, override a forbidden action, self-route Crew, or satisfy verifier independence.
+
+## Bounded read-only Crew cognition
+
+GroX exposes a provider-neutral Crew cognition seam for **Inspect** tours when a Crew cognition provider is separately supplied. The seam consumes:
+
+- a sanitized copy of the sealed Mission Order envelope;
+- the bounded selected specialist craft;
+- the existing bounded relevant Crew memory;
+- observations returned only by governed read/test actions already allowed by that Order.
+
+The first bounded seam deliberately excludes Verify, Repair, and Execute. Those modes retain their existing deterministic execution paths.
+
+Within an Inspect tour, a cognitive Crew provider may request only:
+
+- `fs_list`;
+- `fs_read`;
+- `test_run`.
+
+Every request is still checked against the issued Mission Order, forbidden actions, Mission scope, Vessel-root confinement, Crew capability, Tool Gateway policy, and host restrictions. The provider does not receive an alternate tool path. Requests for mutation or scope escape fail closed rather than falling back to broader execution.
+
+Default resource limits are:
+
+- at most **4** cognitive steps per tour;
+- at most **1** cognitive `test_run` per tour;
+- at most **8,000** characters of a bounded observation supplied back to cognition;
+- at most **4,000** characters in the final cognitive work product.
+
+Provider-facing Order, craft, memory, and observation structures are copied for each call. Provider-local mutation cannot alter executor-owned context, Mission authority, or prior observation history.
+
+Governed cognitive observations are persisted as attributable evidence even if the provider later fails or degrades. Raw file-read content is not copied into persistent cognitive-observation evidence; bounded metadata and hashes are retained. A successful cognitive work product records provider identity, selected craft attribution, selected headings, selected size, relevant memory IDs, observation count, and cognitive test-run count.
+
+Known recoverable provider/contract failures degrade to the existing deterministic Crew executor without widening authority. A policy or authority denial does not silently fall back. Unexpected programming defects remain defects rather than being normalized as ordinary provider failure.
+
+Controlled fake-provider CI can qualify this provider-neutral seam and its boundaries. **That evidence does not by itself establish live model-backed Crew operation.** Any project/session or external model provider requires a separate operational qualification before GroX may claim live model-backed Crew cognition.
 
 ## Qualified A3 gate
 
@@ -92,4 +140,4 @@ A3 qualification was established by demonstrating all of the following:
 
 **Exit gate:** repeated Missions measurably improve routing and execution without indiscriminate context growth.
 
-**Current status:** QUALIFIED. Autonomous memory consolidation remains outside the released Apex baseline until separately evidenced and governed.
+**Current A3 status:** QUALIFIED. Later selective-craft and controlled Crew-cognition hardening are post-Apex extensions and do not redefine the historical A3 gate. Autonomous memory consolidation remains outside the released Apex baseline until separately evidenced and governed.

--- a/docs/specification/MISSION_ORDER.md
+++ b/docs/specification/MISSION_ORDER.md
@@ -43,6 +43,19 @@ A Mission Order is an immutable issued authority contract. Authority-bearing sca
 
 Runtime code must not widen a sealed Order in place. A broader scope, different grant, changed verifier requirement, or altered parameter envelope requires a newly issued bounded Order through GorXu. Serialization preserves the external JSON list/object shapes even though the sealed in-memory authority envelope is immutable.
 
+### Pre-issuance Crew context
+
+Before persistence/sealing, GorXu's Living Company service may add bounded competence context to Order parameters, including:
+
+- task-class metadata;
+- selected relevant Crew memory;
+- selected Mission-relevant sections from the assigned Standing Crew member's canonical craft card;
+- attribution metadata such as craft digest, selected headings, selected size, source revision, and freshness policy.
+
+This context is not authority-bearing. It cannot add an allowed action, remove a forbidden action, expand scope, lower risk, change mode, grant a capability, replace the assigned Crew, or satisfy an independent-verifier requirement. Once the Order is sealed, the contextual parameter envelope is immutable with the rest of the issued Order.
+
+A separately supplied Crew cognition provider receives a sanitized copy of the Order authority envelope rather than arbitrary internal parameters. Provider-local mutation of that copy has no effect on the sealed Order.
+
 ## Inspect mode
 
 Inspect mode is read-and-report by default.
@@ -56,6 +69,8 @@ Typical authority:
 - propose resolutions.
 
 Mutation is forbidden unless a diagnostic mutation is explicitly listed and safely reversible.
+
+A bounded optional Crew cognition provider may assist an Inspect tour using selected craft, selected memory, and governed observations. The provider is not a new authority source. Its action requests must still be present in the sealed Order and pass the existing Tool Gateway. The first bounded seam permits only `fs_list`, `fs_read`, and `test_run`, with hard step/output/test-run limits and Mission-scope confinement. Policy denial fails closed; recoverable provider failure may degrade to the existing deterministic Inspect executor without authority widening.
 
 ## Repair mode
 
@@ -73,11 +88,15 @@ A repair order must make clear:
 
 There is no implicit "while I am here" authority.
 
+The first bounded Crew cognition seam does not operate in Repair mode. A cognitive-provider output cannot create or infer Repair permission.
+
 ## Execute mode
 
 Execute mode covers bounded work that is neither inspection-only nor a repair mutation. Any side-effecting action remains subject to explicit capability and action grants.
 
 A generic Execute directive that has no explicitly governed operation may complete only a bounded context inventory. In the single-Mission Pilot path, that execution is reported at Mission level as `scan_only`, not as proof that the Commander objective was delivered.
+
+The first bounded Crew cognition seam does not replace or reinterpret Execute behavior.
 
 ## Mission outcome versus Order execution
 
@@ -101,6 +120,8 @@ Outcome classification never grants authority. Explicit Repair remains the mutat
 ## Verify mode
 
 Verification receives its own Mission Order and authority envelope. A verifier should not receive mutation capability unless remediation of a verification harness is itself the explicit task.
+
+The first bounded Crew cognition seam does not run in Verify mode. Controlled Crew cognition therefore cannot become an alternate automatic verifier or satisfy an independence requirement by itself.
 
 ## Exception protocol
 

--- a/docs/specification/MISSION_ORDER.md
+++ b/docs/specification/MISSION_ORDER.md
@@ -45,12 +45,13 @@ Runtime code must not widen a sealed Order in place. A broader scope, different 
 
 ### Pre-issuance Crew context
 
-Before persistence/sealing, GorXu's Living Company service may add bounded competence context to Order parameters, including:
+Before persistence/sealing, GorXu's Living Company service may add bounded competence context to Order parameters:
 
 - task-class metadata;
 - selected relevant Crew memory;
-- selected Mission-relevant sections from the assigned Standing Crew member's canonical craft card;
-- attribution metadata such as craft digest, selected headings, selected size, source revision, and freshness policy.
+- for **Inspect** Orders only, selected Mission-relevant sections from the assigned Standing Crew member's canonical craft card plus attribution metadata such as craft digest, selected headings, selected size, source revision, and freshness policy.
+
+Verify, Repair, and Execute Orders retain their normal task/memory context without carrying unused selective deep craft from this first cognition seam.
 
 This context is not authority-bearing. It cannot add an allowed action, remove a forbidden action, expand scope, lower risk, change mode, grant a capability, replace the assigned Crew, or satisfy an independent-verifier requirement. Once the Order is sealed, the contextual parameter envelope is immutable with the rest of the issued Order.
 
@@ -71,6 +72,8 @@ Typical authority:
 Mutation is forbidden unless a diagnostic mutation is explicitly listed and safely reversible.
 
 A bounded optional Crew cognition provider may assist an Inspect tour using selected craft, selected memory, and governed observations. The provider is not a new authority source. Its action requests must still be present in the sealed Order and pass the existing Tool Gateway. The first bounded seam permits only `fs_list`, `fs_read`, and `test_run`, with hard step/output/test-run limits and Mission-scope confinement. Policy denial fails closed; recoverable provider failure may degrade to the existing deterministic Inspect executor without authority widening.
+
+Inspect execution records explicit `craft_selection` evidence when selective craft is attached, even when no Crew cognition provider is configured.
 
 ## Repair mode
 

--- a/src/grox/craft_context.py
+++ b/src/grox/craft_context.py
@@ -50,8 +50,8 @@ def select_craft_context(
     """Select bounded Mission-relevant specialist craft without granting authority.
 
     Selection is deterministic and lexical. Mandatory safety/operational sections
-    receive budget first, then Mission-relevant sections are selected by token
-    overlap. If the objective has no useful overlap, stable craft fundamentals are
+    must fit in full before Mission-relevant sections may consume the remaining
+    budget. If the objective has no useful overlap, stable craft fundamentals are
     used as bounded fallbacks. Complete craft cards are never injected by default.
     """
     max_sections = max(1, int(max_sections))
@@ -62,6 +62,11 @@ def select_craft_context(
     mandatory = [heading for heading in _MANDATORY_HEADINGS if heading in section_map]
     if len(mandatory) > max_sections:
         raise ValueError("craft section budget is too small for mandatory safety context")
+    mandatory_chars = sum(len(section_map[heading]) for heading in mandatory)
+    if mandatory_chars > max_chars:
+        raise ValueError(
+            f"craft character budget is too small for complete mandatory safety context: {mandatory_chars} > {max_chars}"
+        )
 
     scored: list[tuple[int, int, str]] = []
     for position, (heading, text) in enumerate(sections):
@@ -91,21 +96,12 @@ def select_craft_context(
     used_chars = 0
     clipped = False
 
-    # Mandatory sections cannot be starved by an earlier long relevant section.
-    for index, heading in enumerate(mandatory):
+    # Safety/operational binding is never silently clipped to make room for
+    # optional craft. If it cannot fit in full, selection fails closed above.
+    for heading in mandatory:
         text = section_map[heading]
-        remaining = max_chars - used_chars
-        mandatory_left = len(mandatory) - index
-        if remaining <= 0:
-            raise ValueError("craft character budget cannot represent mandatory safety context")
-        fair_share = max(1, remaining // mandatory_left)
-        chosen = text[:fair_share].rstrip()
-        if len(chosen) < len(text):
-            clipped = True
-        if not chosen:
-            raise ValueError(f"craft character budget cannot represent mandatory section: {heading}")
-        context.append({"heading": heading, "content": chosen})
-        used_chars += len(chosen)
+        context.append({"heading": heading, "content": text})
+        used_chars += len(text)
 
     # Relevant/fallback craft receives only the remaining bounded budget.
     for heading in optional:

--- a/src/grox/craft_context.py
+++ b/src/grox/craft_context.py
@@ -50,7 +50,7 @@ def select_craft_context(
     """Select bounded Mission-relevant specialist craft without granting authority.
 
     Selection is deterministic and lexical. Mandatory safety/operational sections
-    are retained when present, then Mission-relevant sections are chosen by token
+    receive budget first, then Mission-relevant sections are selected by token
     overlap. If the objective has no useful overlap, stable craft fundamentals are
     used as bounded fallbacks. Complete craft cards are never injected by default.
     """
@@ -59,14 +59,13 @@ def select_craft_context(
     sections = _sections(card)
     section_map = {heading: text for heading, text in sections}
     objective_words = _words(objective)
-
-    selected_headings: list[str] = [
-        heading for heading in _MANDATORY_HEADINGS if heading in section_map
-    ]
+    mandatory = [heading for heading in _MANDATORY_HEADINGS if heading in section_map]
+    if len(mandatory) > max_sections:
+        raise ValueError("craft section budget is too small for mandatory safety context")
 
     scored: list[tuple[int, int, str]] = []
     for position, (heading, text) in enumerate(sections):
-        if heading in selected_headings:
+        if heading in mandatory:
             continue
         heading_overlap = len(objective_words & _words(heading))
         body_overlap = len(objective_words & _words(text))
@@ -75,33 +74,48 @@ def select_craft_context(
             scored.append((-score, position, heading))
     scored.sort()
 
+    optional: list[str] = []
     for _, _, heading in scored:
-        if heading not in selected_headings:
-            selected_headings.append(heading)
-        if len(selected_headings) >= max_sections:
+        if heading not in optional:
+            optional.append(heading)
+        if len(mandatory) + len(optional) >= max_sections:
             break
-
-    if len(selected_headings) < max_sections:
+    if len(mandatory) + len(optional) < max_sections:
         for heading in _FALLBACK_HEADINGS:
-            if heading in section_map and heading not in selected_headings:
-                selected_headings.append(heading)
-            if len(selected_headings) >= max_sections:
+            if heading in section_map and heading not in mandatory and heading not in optional:
+                optional.append(heading)
+            if len(mandatory) + len(optional) >= max_sections:
                 break
-
-    selected_set = set(selected_headings[:max_sections])
-    ordered = [(heading, text) for heading, text in sections if heading in selected_set]
 
     context: list[dict[str, Any]] = []
     used_chars = 0
     clipped = False
-    for heading, text in ordered:
+
+    # Mandatory sections cannot be starved by an earlier long relevant section.
+    for index, heading in enumerate(mandatory):
+        text = section_map[heading]
+        remaining = max_chars - used_chars
+        mandatory_left = len(mandatory) - index
+        if remaining <= 0:
+            raise ValueError("craft character budget cannot represent mandatory safety context")
+        fair_share = max(1, remaining // mandatory_left)
+        chosen = text[:fair_share].rstrip()
+        if len(chosen) < len(text):
+            clipped = True
+        if not chosen:
+            raise ValueError(f"craft character budget cannot represent mandatory section: {heading}")
+        context.append({"heading": heading, "content": chosen})
+        used_chars += len(chosen)
+
+    # Relevant/fallback craft receives only the remaining bounded budget.
+    for heading in optional:
         remaining = max_chars - used_chars
         if remaining <= 0:
             clipped = True
             break
-        chosen = text
-        if len(chosen) > remaining:
-            chosen = chosen[:remaining].rstrip()
+        text = section_map[heading]
+        chosen = text[:remaining].rstrip()
+        if len(chosen) < len(text):
             clipped = True
         if not chosen:
             continue

--- a/src/grox/craft_context.py
+++ b/src/grox/craft_context.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Any
+
+
+_WORD_RE = re.compile(r"[a-z0-9_-]+")
+_SECTION_RE = re.compile(r"^##\s+(.+?)\s*$", re.MULTILINE)
+_MANDATORY_HEADINGS = ("Purpose", "Safety Boundaries", "GroX Operational Binding")
+_FALLBACK_HEADINGS = ("Responsibilities", "Domain Context", "Identity")
+
+
+def _words(text: str) -> set[str]:
+    return set(_WORD_RE.findall(text.lower()))
+
+
+def _frontmatter_value(card: str, key: str) -> str | None:
+    if not card.startswith("---\n"):
+        return None
+    end = card.find("\n---\n", 4)
+    if end < 0:
+        return None
+    match = re.search(rf"^{re.escape(key)}:\s*(.+?)\s*$", card[4:end], re.MULTILINE)
+    if not match:
+        return None
+    return match.group(1).strip().strip('"\'') or None
+
+
+def _sections(card: str) -> list[tuple[str, str]]:
+    matches = list(_SECTION_RE.finditer(card))
+    sections: list[tuple[str, str]] = []
+    for index, match in enumerate(matches):
+        start = match.start()
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(card)
+        heading = match.group(1).strip()
+        text = card[start:end].strip()
+        if heading and text:
+            sections.append((heading, text))
+    return sections
+
+
+def select_craft_context(
+    card: str,
+    objective: str,
+    *,
+    max_sections: int = 6,
+    max_chars: int = 4500,
+) -> dict[str, Any]:
+    """Select bounded Mission-relevant specialist craft without granting authority.
+
+    Selection is deterministic and lexical. Mandatory safety/operational sections
+    are retained when present, then Mission-relevant sections are chosen by token
+    overlap. If the objective has no useful overlap, stable craft fundamentals are
+    used as bounded fallbacks. Complete craft cards are never injected by default.
+    """
+    max_sections = max(1, int(max_sections))
+    max_chars = max(256, int(max_chars))
+    sections = _sections(card)
+    section_map = {heading: text for heading, text in sections}
+    objective_words = _words(objective)
+
+    selected_headings: list[str] = [
+        heading for heading in _MANDATORY_HEADINGS if heading in section_map
+    ]
+
+    scored: list[tuple[int, int, str]] = []
+    for position, (heading, text) in enumerate(sections):
+        if heading in selected_headings:
+            continue
+        heading_overlap = len(objective_words & _words(heading))
+        body_overlap = len(objective_words & _words(text))
+        score = heading_overlap * 8 + body_overlap
+        if score > 0:
+            scored.append((-score, position, heading))
+    scored.sort()
+
+    for _, _, heading in scored:
+        if heading not in selected_headings:
+            selected_headings.append(heading)
+        if len(selected_headings) >= max_sections:
+            break
+
+    if len(selected_headings) < max_sections:
+        for heading in _FALLBACK_HEADINGS:
+            if heading in section_map and heading not in selected_headings:
+                selected_headings.append(heading)
+            if len(selected_headings) >= max_sections:
+                break
+
+    selected_set = set(selected_headings[:max_sections])
+    ordered = [(heading, text) for heading, text in sections if heading in selected_set]
+
+    context: list[dict[str, Any]] = []
+    used_chars = 0
+    clipped = False
+    for heading, text in ordered:
+        remaining = max_chars - used_chars
+        if remaining <= 0:
+            clipped = True
+            break
+        chosen = text
+        if len(chosen) > remaining:
+            chosen = chosen[:remaining].rstrip()
+            clipped = True
+        if not chosen:
+            continue
+        context.append({"heading": heading, "content": chosen})
+        used_chars += len(chosen)
+        if used_chars >= max_chars:
+            break
+
+    full_sha = hashlib.sha256(card.encode("utf-8")).hexdigest()
+    returned_headings = [item["heading"] for item in context]
+    return {
+        "schema": "grox-selective-craft-context-v1",
+        "craft_sha256": full_sha,
+        "source_revision": _frontmatter_value(card, "source_revision"),
+        "freshness_policy": _frontmatter_value(card, "freshness_policy"),
+        "selected_headings": returned_headings,
+        "selected_sections": context,
+        "selected_chars": used_chars,
+        "card_chars": len(card),
+        "max_sections": max_sections,
+        "max_chars": max_chars,
+        "full_card_injected": False,
+        "truncated": clipped or len(returned_headings) < len(sections) or used_chars < len(card),
+    }

--- a/src/grox/crew_cognition.py
+++ b/src/grox/crew_cognition.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Protocol
+
+
+READ_ONLY_COGNITIVE_ACTIONS = frozenset({"fs_list", "fs_read", "test_run"})
+
+
+class CrewCognitionError(RuntimeError):
+    """Recoverable provider/contract failure that may degrade to deterministic execution."""
+
+
+class CrewCognitionDenied(PermissionError):
+    """A cognitive request attempted to exceed the bounded read-only seam."""
+
+
+@dataclass(frozen=True, slots=True)
+class CrewCognitionStep:
+    action: str
+    path: str | None = None
+    work_product: str | None = None
+
+    @classmethod
+    def from_mapping(cls, raw: Mapping[str, Any]) -> "CrewCognitionStep":
+        if not isinstance(raw, Mapping):
+            raise CrewCognitionError("Crew cognition output must be a mapping")
+        action = raw.get("action")
+        if not isinstance(action, str) or not action.strip():
+            raise CrewCognitionError("Crew cognition action must be a non-empty string")
+        action = action.strip()
+        if action == "finish":
+            work_product = raw.get("work_product")
+            if not isinstance(work_product, str) or not work_product.strip():
+                raise CrewCognitionError("Crew cognition finish requires a non-empty work_product")
+            return cls(action="finish", work_product=work_product.strip())
+        if action not in READ_ONLY_COGNITIVE_ACTIONS:
+            raise CrewCognitionDenied(f"Crew cognition action is outside the read-only seam: {action}")
+        if action in {"fs_list", "fs_read"}:
+            path = raw.get("path")
+            if not isinstance(path, str) or not path.strip():
+                raise CrewCognitionError(f"Crew cognition {action} requires a non-empty path")
+            return cls(action=action, path=path.strip())
+        return cls(action=action)
+
+
+class CrewCognitionProvider(Protocol):
+    name: str
+
+    def next_step(
+        self,
+        *,
+        order: dict[str, Any],
+        craft_context: list[dict[str, Any]],
+        memory_context: list[dict[str, Any]],
+        observations: list[dict[str, Any]],
+    ) -> Mapping[str, Any]: ...

--- a/src/grox/intelligence.py
+++ b/src/grox/intelligence.py
@@ -5,7 +5,7 @@ from types import MappingProxyType
 from dataclasses import dataclass
 from typing import Any, Iterable
 
-from .contracts import MissionOrder, RiskClass, TourResult
+from .contracts import MissionMode, MissionOrder, RiskClass, TourResult
 from .crew.roster import CrewDossier, CrewRoster
 from .craft_context import select_craft_context
 from .state import StateStore
@@ -183,15 +183,18 @@ class LivingCompanyIntelligence:
     def inject_order_context(self, order: MissionOrder, objective: str) -> dict[str, Any]:
         task_class = self.task_class(objective)
         memory = self.memory_context(order.assigned_crew, objective, task_class=task_class)
-        craft = self.craft_context(order.assigned_crew, objective)
-        craft_meta = {key: value for key, value in craft.items() if key != "selected_sections"}
-        order.parameters = {
+        parameters = {
             **dict(order.parameters),
             "_task_class": task_class,
             "_memory_context": memory,
-            "_craft_context": craft["selected_sections"],
-            "_craft_context_meta": craft_meta,
         }
+        craft_meta: dict[str, Any] | None = None
+        if order.mode is MissionMode.inspect:
+            craft = self.craft_context(order.assigned_crew, objective)
+            craft_meta = {key: value for key, value in craft.items() if key != "selected_sections"}
+            parameters["_craft_context"] = craft["selected_sections"]
+            parameters["_craft_context_meta"] = craft_meta
+        order.parameters = parameters
         return {
             "task_class": task_class,
             "memory_count": len(memory),

--- a/src/grox/intelligence.py
+++ b/src/grox/intelligence.py
@@ -14,6 +14,13 @@ _GENERIC_TAGS = {
     "analysis", "code", "engineer", "engineering", "evidence", "inspect",
     "repair", "review", "service", "verify", "write",
 }
+_NON_QUALITY_EVIDENCE = frozenset({
+    "craft_selection",
+    "crew_cognition",
+    "crew_cognition_observation",
+    "crew_cognition_degraded",
+    "crew_cognition_denied",
+})
 _RISK_RANK = {RiskClass.low: 0, RiskClass.medium: 1, RiskClass.high: 2, RiskClass.critical: 3}
 
 _ROUTING_COMPONENT_KEYS = ("competence", "reliability", "evidence_quality", "load", "cost", "latency", "risk", "experience", "preference")
@@ -215,7 +222,7 @@ class LivingCompanyIntelligence:
         verified: bool | None = None,
         cost_units: float = 0.0,
     ) -> None:
-        kinds = {e.kind for e in result.evidence}
+        kinds = {e.kind for e in result.evidence if e.kind not in _NON_QUALITY_EVIDENCE}
         evidence_quality = min(1.0, len(kinds) / 3.0)
         tests = [e for e in result.evidence if e.kind == "test_run"]
         if tests and all(e.content.get("returncode") == 0 for e in tests):

--- a/src/grox/intelligence.py
+++ b/src/grox/intelligence.py
@@ -7,6 +7,7 @@ from typing import Any, Iterable
 
 from .contracts import MissionOrder, RiskClass, TourResult
 from .crew.roster import CrewDossier, CrewRoster
+from .craft_context import select_craft_context
 from .state import StateStore
 
 _GENERIC_TAGS = {
@@ -54,11 +55,22 @@ class RoutingDecision:
 class LivingCompanyIntelligence:
     """Evidence-backed memory retrieval and experienced Crew ranking under GorXu."""
 
-    def __init__(self, store: StateStore, roster: CrewRoster, *, memory_items: int = 6, memory_chars: int = 3000):
+    def __init__(
+        self,
+        store: StateStore,
+        roster: CrewRoster,
+        *,
+        memory_items: int = 6,
+        memory_chars: int = 3000,
+        craft_sections: int = 6,
+        craft_chars: int = 4500,
+    ):
         self.store = store
         self.roster = roster
         self.memory_items = max(1, int(memory_items))
         self.memory_chars = max(256, int(memory_chars))
+        self.craft_sections = max(1, int(craft_sections))
+        self.craft_chars = max(256, int(craft_chars))
         self._known_tags = {tag for crew in roster.all() for tag in crew.tags}
 
     def task_class(self, objective: str) -> str:
@@ -159,15 +171,33 @@ class LivingCompanyIntelligence:
                 break
         return selected
 
+    def craft_context(self, crew_id: str, objective: str) -> dict[str, Any]:
+        card = self.roster.craft_card(crew_id)
+        return select_craft_context(
+            card,
+            objective,
+            max_sections=self.craft_sections,
+            max_chars=self.craft_chars,
+        )
+
     def inject_order_context(self, order: MissionOrder, objective: str) -> dict[str, Any]:
         task_class = self.task_class(objective)
         memory = self.memory_context(order.assigned_crew, objective, task_class=task_class)
+        craft = self.craft_context(order.assigned_crew, objective)
+        craft_meta = {key: value for key, value in craft.items() if key != "selected_sections"}
         order.parameters = {
             **dict(order.parameters),
             "_task_class": task_class,
             "_memory_context": memory,
+            "_craft_context": craft["selected_sections"],
+            "_craft_context_meta": craft_meta,
         }
-        return {"task_class": task_class, "memory_count": len(memory), "memory_ids": [m["memory_id"] for m in memory if m["memory_id"] is not None]}
+        return {
+            "task_class": task_class,
+            "memory_count": len(memory),
+            "memory_ids": [m["memory_id"] for m in memory if m["memory_id"] is not None],
+            "craft": craft_meta,
+        }
 
     def record_performance(
         self,

--- a/src/grox/runtime/executor.py
+++ b/src/grox/runtime/executor.py
@@ -188,7 +188,7 @@ class CrewExecutor:
             return provider,persistent
         raise CrewCognitionDenied(f"Crew cognition action is outside the read-only seam: {step.action}")
 
-    def _run_cognition(self, order:MissionOrder)->tuple[str,list[Evidence]]:
+    def _run_cognition(self, order:MissionOrder)->dict[str,Any]:
         provider=self.cognition_provider
         craft=_plain(order.parameters.get('_craft_context') or [])
         memory=_plain(order.parameters.get('_memory_context') or [])
@@ -196,13 +196,21 @@ class CrewExecutor:
         observations:list[dict[str,Any]]=[]
         evidence:list[Evidence]=[]
         for _ in range(self.cognition_max_steps):
-            raw=provider.next_step(
-                order=self._cognition_order_envelope(order),
-                craft_context=craft,
-                memory_context=memory,
-                observations=observations,
-            )
-            step=CrewCognitionStep.from_mapping(raw)
+            try:
+                raw=provider.next_step(
+                    order=_plain(self._cognition_order_envelope(order)),
+                    craft_context=_plain(craft),
+                    memory_context=_plain(memory),
+                    observations=_plain(observations),
+                )
+            except (CrewCognitionError,ValueError,TypeError) as exc:
+                return {'status':'degraded','error':str(exc),'evidence':evidence}
+            try:
+                step=CrewCognitionStep.from_mapping(raw)
+            except CrewCognitionDenied as exc:
+                return {'status':'denied','error':str(exc),'evidence':evidence}
+            except (CrewCognitionError,ValueError,TypeError) as exc:
+                return {'status':'degraded','error':str(exc),'evidence':evidence}
             if step.action=='finish':
                 evidence.append(Evidence('crew_cognition',{
                     'provider':str(getattr(provider,'name','crew-cognition-provider')),
@@ -214,11 +222,20 @@ class CrewExecutor:
                     'observation_count':len(observations),
                     'mode':'read_only_inspect',
                 }))
-                return step.work_product or '',evidence
-            provider_observation,persistent=self._cognition_observation(order,step)
+                return {'status':'completed','work_product':step.work_product or '','evidence':evidence}
+            try:
+                provider_observation,persistent=self._cognition_observation(order,step)
+            except (CrewCognitionDenied,ToolDenied) as exc:
+                return {'status':'denied','error':str(exc),'evidence':evidence}
+            except (FileNotFoundError,IsADirectoryError,TimeoutError) as exc:
+                return {'status':'degraded','error':str(exc),'evidence':evidence}
             observations.append(provider_observation)
             evidence.append(Evidence('crew_cognition_observation',persistent))
-        raise CrewCognitionError(f"Crew cognition exceeded bounded step limit: {self.cognition_max_steps}")
+        return {
+            'status':'degraded',
+            'error':f"Crew cognition exceeded bounded step limit: {self.cognition_max_steps}",
+            'evidence':evidence,
+        }
 
     def _execute_deterministic(self, order:MissionOrder)->TourResult:
         evidence=[]
@@ -285,25 +302,26 @@ class CrewExecutor:
         # Verify, Repair, and Execute retain their existing deterministic paths.
         if self.cognition_provider is None or order.mode is not MissionMode.inspect:
             return self._execute_deterministic(order)
-        try:
-            work_product,cognitive_evidence=self._run_cognition(order)
-        except CrewCognitionDenied as exc:
+        run=self._run_cognition(order)
+        prior=list(run.get('evidence') or [])
+        if run['status']=='denied':
+            prior.append(Evidence('crew_cognition_denied',{'error':run['error'],'mode':'read_only_inspect'}))
             return TourResult(
-                order.order_id,order.assigned_crew,'exception',str(exc),
-                [Evidence('crew_cognition_denied',{'error':str(exc),'mode':'read_only_inspect'})],
+                order.order_id,order.assigned_crew,'exception',run['error'],prior,
                 {'type':'crew_cognition_denied','recommendation':'Return to GorXu; do not widen Mission Order authority'},
             )
-        except (CrewCognitionError,ValueError,TypeError) as exc:
+        if run['status']=='degraded':
             result=self._execute_deterministic(order)
+            result.evidence=prior+result.evidence
             result.evidence.append(Evidence('crew_cognition_degraded',{
                 'provider':str(getattr(self.cognition_provider,'name','crew-cognition-provider')),
-                'error':str(exc),
+                'error':run['error'],
                 'fallback':'deterministic Crew executor',
             }))
             return result
 
         result=self._execute_deterministic(order)
-        result.evidence.extend(cognitive_evidence)
+        result.evidence.extend(prior)
         if result.status=='completed':
-            result.summary += f"; Crew cognition: {work_product}"
+            result.summary += f"; Crew cognition: {run['work_product']}"
         return result

--- a/src/grox/runtime/executor.py
+++ b/src/grox/runtime/executor.py
@@ -29,11 +29,15 @@ class CrewExecutor:
         cognition_provider:Any=None,
         cognition_max_steps:int=4,
         cognition_observation_chars:int=8000,
+        cognition_max_test_runs:int=1,
+        cognition_work_product_chars:int=4000,
     ):
         self.gateway=gateway; self.store=durable
         self.cognition_provider=cognition_provider
         self.cognition_max_steps=max(1,min(8,int(cognition_max_steps)))
         self.cognition_observation_chars=max(256,min(32000,int(cognition_observation_chars)))
+        self.cognition_max_test_runs=max(0,min(1,int(cognition_max_test_runs)))
+        self.cognition_work_product_chars=max(256,min(8192,int(cognition_work_product_chars)))
 
     def _repair_write_text(self, order:MissionOrder)->TourResult:
         evidence=[]
@@ -195,6 +199,7 @@ class CrewExecutor:
         craft_meta=_plain(order.parameters.get('_craft_context_meta') or {})
         observations:list[dict[str,Any]]=[]
         evidence:list[Evidence]=[]
+        test_runs=0
         for _ in range(self.cognition_max_steps):
             try:
                 raw=provider.next_step(
@@ -212,17 +217,33 @@ class CrewExecutor:
             except (CrewCognitionError,ValueError,TypeError) as exc:
                 return {'status':'degraded','error':str(exc),'evidence':evidence}
             if step.action=='finish':
+                work_product=step.work_product or ''
+                if len(work_product)>self.cognition_work_product_chars:
+                    return {
+                        'status':'degraded',
+                        'error':f"Crew cognition work product exceeds bounded size: {len(work_product)} > {self.cognition_work_product_chars}",
+                        'evidence':evidence,
+                    }
                 evidence.append(Evidence('crew_cognition',{
                     'provider':str(getattr(provider,'name','crew-cognition-provider')),
-                    'work_product':step.work_product,
+                    'work_product':work_product,
                     'craft_sha256':craft_meta.get('craft_sha256'),
                     'selected_headings':craft_meta.get('selected_headings') or [],
                     'selected_chars':craft_meta.get('selected_chars'),
                     'memory_ids':[item.get('memory_id') for item in memory if isinstance(item,dict) and item.get('memory_id') is not None],
                     'observation_count':len(observations),
+                    'test_run_count':test_runs,
                     'mode':'read_only_inspect',
                 }))
-                return {'status':'completed','work_product':step.work_product or '','evidence':evidence}
+                return {'status':'completed','work_product':work_product,'evidence':evidence}
+            if step.action=='test_run':
+                if test_runs>=self.cognition_max_test_runs:
+                    return {
+                        'status':'denied',
+                        'error':f"Crew cognition test_run budget exceeded: {self.cognition_max_test_runs}",
+                        'evidence':evidence,
+                    }
+                test_runs+=1
             try:
                 provider_observation,persistent=self._cognition_observation(order,step)
             except (CrewCognitionDenied,ToolDenied) as exc:

--- a/src/grox/runtime/executor.py
+++ b/src/grox/runtime/executor.py
@@ -258,6 +258,14 @@ class CrewExecutor:
             'evidence':evidence,
         }
 
+    def _craft_selection_evidence(self, order:MissionOrder)->Evidence|None:
+        if order.mode is not MissionMode.inspect:
+            return None
+        meta=_plain(order.parameters.get('_craft_context_meta') or {})
+        if not meta:
+            return None
+        return Evidence('craft_selection',meta)
+
     def _execute_deterministic(self, order:MissionOrder)->TourResult:
         evidence=[]
         try:
@@ -321,10 +329,16 @@ class CrewExecutor:
     def execute(self, order:MissionOrder)->TourResult:
         # The first Crew-cognition slice is deliberately read-only Inspect only.
         # Verify, Repair, and Execute retain their existing deterministic paths.
+        craft_evidence=self._craft_selection_evidence(order)
         if self.cognition_provider is None or order.mode is not MissionMode.inspect:
-            return self._execute_deterministic(order)
+            result=self._execute_deterministic(order)
+            if craft_evidence is not None:
+                result.evidence.insert(0,craft_evidence)
+            return result
         run=self._run_cognition(order)
         prior=list(run.get('evidence') or [])
+        if craft_evidence is not None:
+            prior.insert(0,craft_evidence)
         if run['status']=='denied':
             prior.append(Evidence('crew_cognition_denied',{'error':run['error'],'mode':'read_only_inspect'}))
             return TourResult(
@@ -342,7 +356,7 @@ class CrewExecutor:
             return result
 
         result=self._execute_deterministic(order)
-        result.evidence.extend(prior)
+        result.evidence=prior+result.evidence
         if result.status=='completed':
             result.summary += f"; Crew cognition: {run['work_product']}"
         return result

--- a/src/grox/runtime/executor.py
+++ b/src/grox/runtime/executor.py
@@ -1,12 +1,39 @@
 from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
 import hashlib
+import json
+from typing import Any
+
 from ..contracts import MissionOrder, MissionMode, TourResult, Evidence
+from ..crew_cognition import CrewCognitionDenied, CrewCognitionError, CrewCognitionStep
 from ..tools.gateway import ToolGateway, ToolDenied
 from ..durable_state import DurableState
 
+
+def _plain(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {key: _plain(item) for key, item in value.items()}
+    if isinstance(value, (tuple, list)):
+        return [_plain(item) for item in value]
+    return value
+
+
 class CrewExecutor:
-    def __init__(self, gateway:ToolGateway, durable:DurableState|None=None):
+    def __init__(
+        self,
+        gateway:ToolGateway,
+        durable:DurableState|None=None,
+        *,
+        cognition_provider:Any=None,
+        cognition_max_steps:int=4,
+        cognition_observation_chars:int=8000,
+    ):
         self.gateway=gateway; self.store=durable
+        self.cognition_provider=cognition_provider
+        self.cognition_max_steps=max(1,min(8,int(cognition_max_steps)))
+        self.cognition_observation_chars=max(256,min(32000,int(cognition_observation_chars)))
 
     def _repair_write_text(self, order:MissionOrder)->TourResult:
         evidence=[]
@@ -97,7 +124,103 @@ class CrewExecutor:
             self.store.update_mutation(key,'verified',after_sha256=self.gateway.current_hash(target))
         return TourResult(order.order_id,order.assigned_crew,'completed',f"Repaired {target}",evidence)
 
-    def execute(self, order:MissionOrder)->TourResult:
+    def _cognition_order_envelope(self, order:MissionOrder)->dict[str,Any]:
+        return {
+            'mission_id':order.mission_id,
+            'order_id':order.order_id,
+            'commander_intent':order.commander_intent,
+            'objective':order.objective,
+            'mode':order.mode.value,
+            'assigned_crew':order.assigned_crew,
+            'required_capabilities':list(order.required_capabilities),
+            'allowed_actions':list(order.allowed_actions),
+            'forbidden_actions':list(order.forbidden_actions),
+            'scope':list(order.scope),
+            'risk_class':order.risk_class.value,
+            'stop_conditions':list(order.stop_conditions),
+        }
+
+    def _assert_cognition_scope(self, order:MissionOrder, rel:str)->None:
+        if not rel or Path(rel).is_absolute():
+            raise CrewCognitionDenied(f"Crew cognition path is outside Mission scope: {rel}")
+        root=self.gateway.root.resolve()
+        target=(root/rel).resolve()
+        try:
+            target.relative_to(root)
+        except ValueError as exc:
+            raise CrewCognitionDenied(f"Crew cognition path escapes Vessel root: {rel}") from exc
+        for scope_rel in order.scope or ('.',):
+            scope=(root/scope_rel).resolve()
+            try:
+                scope.relative_to(root)
+            except ValueError:
+                continue
+            if target==scope or target.is_relative_to(scope):
+                return
+        raise CrewCognitionDenied(f"Crew cognition path is outside Mission scope: {rel}")
+
+    def _cognition_observation(self, order:MissionOrder, step:CrewCognitionStep)->tuple[dict[str,Any],dict[str,Any]]:
+        if step.action in order.forbidden_actions or step.action not in order.allowed_actions:
+            raise CrewCognitionDenied(f"Crew cognition action not granted by Mission Order: {step.action}")
+        if step.action in {'fs_list','fs_read'}:
+            assert step.path is not None
+            self._assert_cognition_scope(order,step.path)
+        if step.action=='fs_list':
+            files=self.gateway.list_path(order,step.path or '.')
+            visible=files[:100]
+            provider={'action':'fs_list','path':step.path,'files':visible,'count':len(files),'truncated':len(files)>len(visible)}
+            persistent={'action':'fs_list','path':step.path,'count':len(files),'visible_count':len(visible),
+                        'sha256':hashlib.sha256(json.dumps(visible,sort_keys=True).encode()).hexdigest()}
+            return provider,persistent
+        if step.action=='fs_read':
+            text=self.gateway.read_text(order,step.path or '.',limit=self.cognition_observation_chars)
+            provider={'action':'fs_read','path':step.path,'content':text,'chars':len(text)}
+            persistent={'action':'fs_read','path':step.path,'chars':len(text),'sha256':hashlib.sha256(text.encode()).hexdigest()}
+            return provider,persistent
+        if step.action=='test_run':
+            result=self.gateway.run_tests(order)
+            stdout=str(result.get('stdout') or '')[-self.cognition_observation_chars//2:]
+            stderr=str(result.get('stderr') or '')[-self.cognition_observation_chars//2:]
+            provider={'action':'test_run','returncode':result.get('returncode'),'stdout':stdout,'stderr':stderr}
+            persistent={'action':'test_run','returncode':result.get('returncode'),
+                        'stdout_sha256':hashlib.sha256(stdout.encode()).hexdigest(),
+                        'stderr_sha256':hashlib.sha256(stderr.encode()).hexdigest()}
+            return provider,persistent
+        raise CrewCognitionDenied(f"Crew cognition action is outside the read-only seam: {step.action}")
+
+    def _run_cognition(self, order:MissionOrder)->tuple[str,list[Evidence]]:
+        provider=self.cognition_provider
+        craft=_plain(order.parameters.get('_craft_context') or [])
+        memory=_plain(order.parameters.get('_memory_context') or [])
+        craft_meta=_plain(order.parameters.get('_craft_context_meta') or {})
+        observations:list[dict[str,Any]]=[]
+        evidence:list[Evidence]=[]
+        for _ in range(self.cognition_max_steps):
+            raw=provider.next_step(
+                order=self._cognition_order_envelope(order),
+                craft_context=craft,
+                memory_context=memory,
+                observations=observations,
+            )
+            step=CrewCognitionStep.from_mapping(raw)
+            if step.action=='finish':
+                evidence.append(Evidence('crew_cognition',{
+                    'provider':str(getattr(provider,'name','crew-cognition-provider')),
+                    'work_product':step.work_product,
+                    'craft_sha256':craft_meta.get('craft_sha256'),
+                    'selected_headings':craft_meta.get('selected_headings') or [],
+                    'selected_chars':craft_meta.get('selected_chars'),
+                    'memory_ids':[item.get('memory_id') for item in memory if isinstance(item,dict) and item.get('memory_id') is not None],
+                    'observation_count':len(observations),
+                    'mode':'read_only_inspect',
+                }))
+                return step.work_product or '',evidence
+            provider_observation,persistent=self._cognition_observation(order,step)
+            observations.append(provider_observation)
+            evidence.append(Evidence('crew_cognition_observation',persistent))
+        raise CrewCognitionError(f"Crew cognition exceeded bounded step limit: {self.cognition_max_steps}")
+
+    def _execute_deterministic(self, order:MissionOrder)->TourResult:
         evidence=[]
         try:
             if order.mode in {MissionMode.inspect,MissionMode.verify}:
@@ -156,3 +279,31 @@ class CrewExecutor:
             return TourResult(order.order_id,order.assigned_crew,'completed',f"Executed bounded mission context scan across {len(files)} files",evidence)
         except (ToolDenied,FileNotFoundError,IsADirectoryError,TimeoutError) as e:
             return TourResult(order.order_id,order.assigned_crew,'exception',str(e),evidence,{'type':type(e).__name__,'recommendation':'Return to GorXu; do not widen authority'})
+
+    def execute(self, order:MissionOrder)->TourResult:
+        # The first Crew-cognition slice is deliberately read-only Inspect only.
+        # Verify, Repair, and Execute retain their existing deterministic paths.
+        if self.cognition_provider is None or order.mode is not MissionMode.inspect:
+            return self._execute_deterministic(order)
+        try:
+            work_product,cognitive_evidence=self._run_cognition(order)
+        except CrewCognitionDenied as exc:
+            return TourResult(
+                order.order_id,order.assigned_crew,'exception',str(exc),
+                [Evidence('crew_cognition_denied',{'error':str(exc),'mode':'read_only_inspect'})],
+                {'type':'crew_cognition_denied','recommendation':'Return to GorXu; do not widen Mission Order authority'},
+            )
+        except (CrewCognitionError,ValueError,TypeError) as exc:
+            result=self._execute_deterministic(order)
+            result.evidence.append(Evidence('crew_cognition_degraded',{
+                'provider':str(getattr(self.cognition_provider,'name','crew-cognition-provider')),
+                'error':str(exc),
+                'fallback':'deterministic Crew executor',
+            }))
+            return result
+
+        result=self._execute_deterministic(order)
+        result.evidence.extend(cognitive_evidence)
+        if result.status=='completed':
+            result.summary += f"; Crew cognition: {work_product}"
+        return result

--- a/tests/_support.py
+++ b/tests/_support.py
@@ -60,6 +60,15 @@ Pilot GorXu remains sole operational orchestrator. Mission authority and Repair 
 '''
 
 
+def add_synthetic_crew(root: Path, dossier: dict) -> None:
+    """Add one synthetic Crew identity with the same craft-card invariant as production."""
+    (root/'configs/crew/dossiers').mkdir(parents=True, exist_ok=True)
+    (root/'configs/crew/specialists').mkdir(parents=True, exist_ok=True)
+    crew_id=dossier['crew_id']
+    (root/'configs/crew/dossiers'/f"{crew_id}.json").write_text(json.dumps(dossier))
+    (root/'configs/crew/specialists'/f"{crew_id}.md").write_text(_synthetic_craft(dossier))
+
+
 def temp_vessel():
     td=tempfile.TemporaryDirectory(); root=Path(td.name)
     (root/'configs/crew/dossiers').mkdir(parents=True); (root/'configs/crew/specialists').mkdir(parents=True)
@@ -68,6 +77,5 @@ def temp_vessel():
     # A tiny always-passing nested test for ToolGateway.run_tests
     (root/'tests/test_smoke.py').write_text('import unittest\nclass T(unittest.TestCase):\n def test_ok(self): self.assertTrue(True)\n')
     for d in CREW:
-        (root/'configs/crew/dossiers'/f"{d['crew_id']}.json").write_text(json.dumps(d))
-        (root/'configs/crew/specialists'/f"{d['crew_id']}.md").write_text(_synthetic_craft(d))
+        add_synthetic_crew(root,d)
     return td,root,PilotGorXu(root)

--- a/tests/_support.py
+++ b/tests/_support.py
@@ -9,11 +9,65 @@ CREW=[
 {"crew_id":"independent-verifier","division":"verification","title":"Independent Verifier","capabilities":["repo_read","verify","test_run"],"tags":["verify","evidence"],"ordinary_routing":False,"verification":True},
 ]
 
+
+def _synthetic_craft(dossier):
+    crew_id=dossier['crew_id']
+    title=dossier['title']
+    tags=', '.join(dossier.get('tags',[]))
+    return f'''---
+name: {crew_id}
+description: Synthetic test craft for {title}
+freshness_policy: test-fixture
+source_repository: GroX-test-fixture
+source_revision: test
+---
+
+## Identity
+
+{title} test identity for bounded GroX regression fixtures.
+
+## Purpose
+
+Perform {tags or 'bounded'} work only within the issued Mission Order.
+
+## Domain Context
+
+Synthetic regression context for {tags or 'general'} tasks.
+
+## Responsibilities
+
+Inspect evidence, follow scope, and return bounded results to Pilot GorXu.
+
+## Non-Responsibilities
+
+Do not create authority, route other Crew, or widen scope.
+
+## Inputs
+
+Mission Order, bounded source evidence, and selected memory.
+
+## Outputs
+
+Attributable bounded evidence for regression tests.
+
+## Safety Boundaries
+
+Never infer Repair permission from expertise or natural-language wording.
+
+## GroX Operational Binding
+
+Pilot GorXu remains sole operational orchestrator. Mission authority and Repair permission come only from the existing GroX authority path.
+'''
+
+
 def temp_vessel():
     td=tempfile.TemporaryDirectory(); root=Path(td.name)
-    (root/'configs/crew/dossiers').mkdir(parents=True); (root/'tests').mkdir(); (root/'docs').mkdir()
+    (root/'configs/crew/dossiers').mkdir(parents=True); (root/'configs/crew/specialists').mkdir(parents=True)
+    (root/'tests').mkdir(); (root/'docs').mkdir()
     (root/'README.md').write_text('# test\n')
     # A tiny always-passing nested test for ToolGateway.run_tests
     (root/'tests/test_smoke.py').write_text('import unittest\nclass T(unittest.TestCase):\n def test_ok(self): self.assertTrue(True)\n')
-    for d in CREW: (root/'configs/crew/dossiers'/f"{d['crew_id']}.json").write_text(json.dumps(d))
+    for d in CREW:
+        (root/'configs/crew/dossiers'/f"{d['crew_id']}.json").write_text(json.dumps(d))
+        (root/'configs/crew/specialists'/f"{d['crew_id']}.md").write_text(_synthetic_craft(d))
     return td,root,PilotGorXu(root)

--- a/tests/_support.py
+++ b/tests/_support.py
@@ -9,6 +9,13 @@ CREW=[
 {"crew_id":"independent-verifier","division":"verification","title":"Independent Verifier","capabilities":["repo_read","verify","test_run"],"tags":["verify","evidence"],"ordinary_routing":False,"verification":True},
 ]
 
+# Some integration fixtures add these dossiers after temp_vessel() returns. Their
+# craft stubs are pre-provisioned so the synthetic Vessel preserves the same
+# dossier-to-craft invariant as production when those dossiers are activated.
+DYNAMIC_CRAFT_FIXTURES=[
+{"crew_id":"devops-engineer","division":"platform","title":"DevOps Engineer","capabilities":["repo_read","workspace_exec"],"tags":["workspace","platform","runtime"]},
+]
+
 
 def _synthetic_craft(dossier):
     crew_id=dossier['crew_id']
@@ -78,4 +85,6 @@ def temp_vessel():
     (root/'tests/test_smoke.py').write_text('import unittest\nclass T(unittest.TestCase):\n def test_ok(self): self.assertTrue(True)\n')
     for d in CREW:
         add_synthetic_crew(root,d)
+    for d in DYNAMIC_CRAFT_FIXTURES:
+        (root/'configs/crew/specialists'/f"{d['crew_id']}.md").write_text(_synthetic_craft(d))
     return td,root,PilotGorXu(root)

--- a/tests/integration/test_crew_cognition.py
+++ b/tests/integration/test_crew_cognition.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 
 from grox.contracts import MissionMode
@@ -65,6 +66,11 @@ class CountingProvider:
         return {'action':'finish','work_product':'should not be called'}
 
 
+def _evidence_content(row):
+    content=row['content']
+    return json.loads(content) if isinstance(content,str) else content
+
+
 class CrewCognitionIntegrationTests(unittest.TestCase):
     def test_inspect_consumes_selective_craft_memory_and_governed_observation(self):
         td,root,p=temp_vessel()
@@ -91,16 +97,16 @@ class CrewCognitionIntegrationTests(unittest.TestCase):
             mission=p.store.mission(result['mission_id'])
             evidence=[e for e in mission['evidence'] if e['kind'] in {'crew_cognition','crew_cognition_observation'}]
             self.assertEqual(len([e for e in evidence if e['kind']=='crew_cognition']),1)
-            observation=next(e for e in evidence if e['kind']=='crew_cognition_observation')
-            self.assertEqual(observation['content']['action'],'fs_read')
-            self.assertEqual(observation['content']['path'],'README.md')
-            self.assertIn('sha256',observation['content'])
-            self.assertNotIn('content',observation['content'])
-            cognition=next(e for e in evidence if e['kind']=='crew_cognition')
-            self.assertEqual(cognition['content']['provider'],provider.name)
-            self.assertGreater(cognition['content']['selected_chars'],0)
-            self.assertIn('GroX Operational Binding',cognition['content']['selected_headings'])
-            self.assertGreaterEqual(cognition['content']['observation_count'],1)
+            observation=_evidence_content(next(e for e in evidence if e['kind']=='crew_cognition_observation'))
+            self.assertEqual(observation['action'],'fs_read')
+            self.assertEqual(observation['path'],'README.md')
+            self.assertIn('sha256',observation)
+            self.assertNotIn('content',observation)
+            cognition=_evidence_content(next(e for e in evidence if e['kind']=='crew_cognition'))
+            self.assertEqual(cognition['provider'],provider.name)
+            self.assertGreater(cognition['selected_chars'],0)
+            self.assertIn('GroX Operational Binding',cognition['selected_headings'])
+            self.assertGreaterEqual(cognition['observation_count'],1)
         finally:
             td.cleanup()
 
@@ -126,7 +132,7 @@ class CrewCognitionIntegrationTests(unittest.TestCase):
             result=p.command('Inspect docs only',mode=MissionMode.inspect,crew_id='backend-engineer',scope='docs')
             self.assertEqual(result['status'],'exception')
             self.assertEqual(result['exception']['type'],'crew_cognition_denied')
-            self.assertIn('scope',result['summary'])
+            self.assertIn('escapes Vessel root',result['summary'])
         finally:
             td.cleanup()
 
@@ -168,9 +174,9 @@ class CrewCognitionIntegrationTests(unittest.TestCase):
             self.assertEqual(result['status'],'completed')
             self.assertTrue(result['synthesis']['verification_passed'])
             mission=p.store.mission(result['mission_id'])
-            cognitive=[e for e in mission['evidence'] if e['kind']=='crew_cognition']
+            cognitive=[_evidence_content(e) for e in mission['evidence'] if e['kind']=='crew_cognition']
             self.assertGreaterEqual(len(cognitive),5)
-            self.assertTrue(all(e['content']['mode']=='read_only_inspect' for e in cognitive))
+            self.assertTrue(all(content['mode']=='read_only_inspect' for content in cognitive))
             verifier_orders=[o for o in mission['orders'] if o['mode']=='verify']
             self.assertEqual(len(verifier_orders),1)
             verifier_evidence=[e for e in mission['evidence'] if e['order_id']==verifier_orders[0]['order_id']]

--- a/tests/integration/test_crew_cognition.py
+++ b/tests/integration/test_crew_cognition.py
@@ -85,6 +85,20 @@ class MutatingInputProvider:
         return {'action':'finish','work_product':'Provider-local mutations did not alter executor-owned context.'}
 
 
+class RepeatTestProvider:
+    name='fake-repeat-test'
+
+    def next_step(self, **kwargs):
+        return {'action':'test_run'}
+
+
+class OversizedWorkProductProvider:
+    name='fake-oversized-output'
+
+    def next_step(self, **kwargs):
+        return {'action':'finish','work_product':'x'*5000}
+
+
 class CountingProvider:
     name='fake-counting-provider'
 
@@ -137,6 +151,7 @@ class CrewCognitionIntegrationTests(unittest.TestCase):
             self.assertGreater(cognition['selected_chars'],0)
             self.assertIn('GroX Operational Binding',cognition['selected_headings'])
             self.assertGreaterEqual(cognition['observation_count'],1)
+            self.assertEqual(cognition['test_run_count'],0)
         finally:
             td.cleanup()
 
@@ -218,6 +233,38 @@ class CrewCognitionIntegrationTests(unittest.TestCase):
             mission=p.store.mission(result['mission_id'])
             cognition=_evidence_content(next(e for e in mission['evidence'] if e['kind']=='crew_cognition'))
             self.assertEqual(cognition['observation_count'],1)
+        finally:
+            td.cleanup()
+
+    def test_cognitive_test_run_is_limited_to_one_per_tour(self):
+        td,root,p=temp_vessel()
+        try:
+            p.executor.cognition_provider=RepeatTestProvider()
+            result=p.command('Inspect and test the Vessel',mode=MissionMode.inspect,crew_id='backend-engineer')
+            self.assertEqual(result['status'],'exception')
+            self.assertEqual(result['exception']['type'],'crew_cognition_denied')
+            self.assertIn('test_run budget exceeded: 1',result['summary'])
+            mission=p.store.mission(result['mission_id'])
+            observations=[_evidence_content(e) for e in mission['evidence'] if e['kind']=='crew_cognition_observation']
+            self.assertEqual(len(observations),1)
+            self.assertEqual(observations[0]['action'],'test_run')
+            self.assertIn('crew_cognition_denied',{e['kind'] for e in mission['evidence']})
+        finally:
+            td.cleanup()
+
+    def test_oversized_work_product_degrades_without_persisting_unbounded_output(self):
+        td,root,p=temp_vessel()
+        try:
+            p.executor.cognition_provider=OversizedWorkProductProvider()
+            result=p.command('Inspect the Vessel',mode=MissionMode.inspect,crew_id='backend-engineer')
+            self.assertEqual(result['status'],'completed')
+            self.assertNotIn('x'*256,result['summary'])
+            mission=p.store.mission(result['mission_id'])
+            kinds={e['kind'] for e in mission['evidence']}
+            self.assertIn('crew_cognition_degraded',kinds)
+            self.assertNotIn('crew_cognition',kinds)
+            degraded=_evidence_content(next(e for e in mission['evidence'] if e['kind']=='crew_cognition_degraded'))
+            self.assertIn('work product exceeds bounded size',degraded['error'])
         finally:
             td.cleanup()
 

--- a/tests/integration/test_crew_cognition.py
+++ b/tests/integration/test_crew_cognition.py
@@ -1,0 +1,183 @@
+import unittest
+
+from grox.contracts import MissionMode
+from grox.crew_cognition import CrewCognitionError
+from tests._support import temp_vessel
+from tests.integration.test_mission_graph import graph_vessel, qualification_plan
+
+
+class ReadThenFinishProvider:
+    name='fake-read-then-finish'
+
+    def __init__(self):
+        self.calls=[]
+
+    def next_step(self, *, order, craft_context, memory_context, observations):
+        self.calls.append({
+            'order':order,
+            'craft_context':craft_context,
+            'memory_context':memory_context,
+            'observations':observations,
+        })
+        if not observations:
+            return {'action':'fs_read','path':'README.md'}
+        return {'action':'finish','work_product':'README evidence inspected with bounded Crew craft.'}
+
+
+class ScopeListThenFinishProvider:
+    name='fake-scope-list'
+
+    def next_step(self, *, order, craft_context, memory_context, observations):
+        if not observations:
+            return {'action':'fs_list','path':order['scope'][0]}
+        return {'action':'finish','work_product':f"Inspected bounded scope for {order['assigned_crew']}."}
+
+
+class WriteAttemptProvider:
+    name='fake-write-attempt'
+
+    def next_step(self, **kwargs):
+        return {'action':'fs_write','path':'docs/forbidden.txt'}
+
+
+class EscapeAttemptProvider:
+    name='fake-scope-escape'
+
+    def next_step(self, **kwargs):
+        return {'action':'fs_read','path':'../outside.txt'}
+
+
+class RecoverableFailureProvider:
+    name='fake-recoverable-failure'
+
+    def next_step(self, **kwargs):
+        raise CrewCognitionError('injected recoverable provider failure')
+
+
+class CountingProvider:
+    name='fake-counting-provider'
+
+    def __init__(self):
+        self.calls=0
+
+    def next_step(self, **kwargs):
+        self.calls+=1
+        return {'action':'finish','work_product':'should not be called'}
+
+
+class CrewCognitionIntegrationTests(unittest.TestCase):
+    def test_inspect_consumes_selective_craft_memory_and_governed_observation(self):
+        td,root,p=temp_vessel()
+        try:
+            p.intelligence.remember(
+                kind='semantic',scope='crew',crew_id='backend-engineer',memory_key='readme-review',
+                content='README backend inspection evidence should be checked before conclusions.',
+                provenance={'mission_id':'M-craft-memory'},
+            )
+            provider=ReadThenFinishProvider()
+            p.executor.cognition_provider=provider
+            result=p.command('Inspect README backend evidence',mode=MissionMode.inspect,crew_id='backend-engineer')
+            self.assertEqual(result['status'],'completed')
+            self.assertIn('Crew cognition: README evidence inspected',result['summary'])
+            self.assertGreaterEqual(len(provider.calls),2)
+            first=provider.calls[0]
+            headings={item['heading'] for item in first['craft_context']}
+            self.assertIn('Purpose',headings)
+            self.assertIn('Safety Boundaries',headings)
+            self.assertIn('GroX Operational Binding',headings)
+            self.assertTrue(any('README backend inspection evidence' in m['content'] for m in first['memory_context']))
+            self.assertNotIn('parameters',first['order'])
+
+            mission=p.store.mission(result['mission_id'])
+            evidence=[e for e in mission['evidence'] if e['kind'] in {'crew_cognition','crew_cognition_observation'}]
+            self.assertEqual(len([e for e in evidence if e['kind']=='crew_cognition']),1)
+            observation=next(e for e in evidence if e['kind']=='crew_cognition_observation')
+            self.assertEqual(observation['content']['action'],'fs_read')
+            self.assertEqual(observation['content']['path'],'README.md')
+            self.assertIn('sha256',observation['content'])
+            self.assertNotIn('content',observation['content'])
+            cognition=next(e for e in evidence if e['kind']=='crew_cognition')
+            self.assertEqual(cognition['content']['provider'],provider.name)
+            self.assertGreater(cognition['content']['selected_chars'],0)
+            self.assertIn('GroX Operational Binding',cognition['content']['selected_headings'])
+            self.assertGreaterEqual(cognition['content']['observation_count'],1)
+        finally:
+            td.cleanup()
+
+    def test_mutating_cognition_request_fails_closed_without_fallback_or_mutation(self):
+        td,root,p=temp_vessel()
+        try:
+            p.executor.cognition_provider=WriteAttemptProvider()
+            result=p.command('Inspect safely',mode=MissionMode.inspect,crew_id='backend-engineer')
+            self.assertEqual(result['status'],'exception')
+            self.assertEqual(result['exception']['type'],'crew_cognition_denied')
+            self.assertFalse((root/'docs/forbidden.txt').exists())
+            mission=p.store.mission(result['mission_id'])
+            kinds={e['kind'] for e in mission['evidence']}
+            self.assertIn('crew_cognition_denied',kinds)
+            self.assertNotIn('inventory',kinds)
+        finally:
+            td.cleanup()
+
+    def test_read_request_outside_mission_scope_fails_closed(self):
+        td,root,p=temp_vessel()
+        try:
+            p.executor.cognition_provider=EscapeAttemptProvider()
+            result=p.command('Inspect docs only',mode=MissionMode.inspect,crew_id='backend-engineer',scope='docs')
+            self.assertEqual(result['status'],'exception')
+            self.assertEqual(result['exception']['type'],'crew_cognition_denied')
+            self.assertIn('scope',result['summary'])
+        finally:
+            td.cleanup()
+
+    def test_recoverable_provider_failure_degrades_to_existing_deterministic_executor(self):
+        td,root,p=temp_vessel()
+        try:
+            p.executor.cognition_provider=RecoverableFailureProvider()
+            result=p.command('Inspect the Vessel',mode=MissionMode.inspect,crew_id='backend-engineer')
+            self.assertEqual(result['status'],'completed')
+            mission=p.store.mission(result['mission_id'])
+            kinds={e['kind'] for e in mission['evidence']}
+            self.assertIn('crew_cognition_degraded',kinds)
+            self.assertIn('inventory',kinds)
+            self.assertIn('test_run',kinds)
+        finally:
+            td.cleanup()
+
+    def test_repair_never_enters_crew_cognition_seam(self):
+        td,root,p=temp_vessel()
+        try:
+            provider=CountingProvider()
+            p.executor.cognition_provider=provider
+            result=p.command(
+                'Repair the bounded test file',mode=MissionMode.repair,crew_id='backend-engineer',scope='docs/cognitive-repair.txt',
+                parameters={'operation':'write_text','path':'docs/cognitive-repair.txt','content':'bounded repair\n'},
+            )
+            self.assertEqual(result['status'],'completed')
+            self.assertEqual(provider.calls,0)
+            self.assertEqual((root/'docs/cognitive-repair.txt').read_text(),'bounded repair\n')
+        finally:
+            td.cleanup()
+
+    def test_mission_graph_inspect_nodes_share_same_bounded_cognition_seam(self):
+        td,root,p=graph_vessel()
+        try:
+            p.executor.cognition_provider=ScopeListThenFinishProvider()
+            directive='Inspect the Vessel across architecture, research, data, implementation, and security, then verify the combined result.'
+            result=p.command_graph(directive,plan=qualification_plan(directive),plan_source='crew-cognition-controlled')
+            self.assertEqual(result['status'],'completed')
+            self.assertTrue(result['synthesis']['verification_passed'])
+            mission=p.store.mission(result['mission_id'])
+            cognitive=[e for e in mission['evidence'] if e['kind']=='crew_cognition']
+            self.assertGreaterEqual(len(cognitive),5)
+            self.assertTrue(all(e['content']['mode']=='read_only_inspect' for e in cognitive))
+            verifier_orders=[o for o in mission['orders'] if o['mode']=='verify']
+            self.assertEqual(len(verifier_orders),1)
+            verifier_evidence=[e for e in mission['evidence'] if e['order_id']==verifier_orders[0]['order_id']]
+            self.assertFalse(any(e['kind']=='crew_cognition' for e in verifier_evidence))
+        finally:
+            td.cleanup()
+
+
+if __name__=='__main__':
+    unittest.main()

--- a/tests/integration/test_crew_cognition.py
+++ b/tests/integration/test_crew_cognition.py
@@ -55,6 +55,36 @@ class RecoverableFailureProvider:
         raise CrewCognitionError('injected recoverable provider failure')
 
 
+class FailAfterReadProvider:
+    name='fake-fail-after-read'
+
+    def next_step(self, *, observations, **kwargs):
+        if not observations:
+            return {'action':'fs_read','path':'README.md'}
+        raise CrewCognitionError('injected failure after governed read')
+
+
+class MutatingInputProvider:
+    name='fake-mutating-input'
+
+    def __init__(self):
+        self.snapshots=[]
+
+    def next_step(self, *, order, craft_context, memory_context, observations):
+        self.snapshots.append({
+            'craft_headings':[item['heading'] for item in craft_context],
+            'memory_count':len(memory_context),
+            'observation_count':len(observations),
+        })
+        if not observations:
+            craft_context.clear()
+            memory_context.clear()
+            observations.append({'action':'fake','content':'provider-local mutation'})
+            order['scope'].clear()
+            return {'action':'fs_read','path':'README.md'}
+        return {'action':'finish','work_product':'Provider-local mutations did not alter executor-owned context.'}
+
+
 class CountingProvider:
     name='fake-counting-provider'
 
@@ -147,6 +177,47 @@ class CrewCognitionIntegrationTests(unittest.TestCase):
             self.assertIn('crew_cognition_degraded',kinds)
             self.assertIn('inventory',kinds)
             self.assertIn('test_run',kinds)
+        finally:
+            td.cleanup()
+
+    def test_governed_observation_remains_evidenced_when_provider_then_degrades(self):
+        td,root,p=temp_vessel()
+        try:
+            p.executor.cognition_provider=FailAfterReadProvider()
+            result=p.command('Inspect README evidence',mode=MissionMode.inspect,crew_id='backend-engineer')
+            self.assertEqual(result['status'],'completed')
+            mission=p.store.mission(result['mission_id'])
+            kinds=[e['kind'] for e in mission['evidence']]
+            self.assertIn('crew_cognition_observation',kinds)
+            self.assertIn('crew_cognition_degraded',kinds)
+            observation=_evidence_content(next(e for e in mission['evidence'] if e['kind']=='crew_cognition_observation'))
+            self.assertEqual(observation['action'],'fs_read')
+            self.assertEqual(observation['path'],'README.md')
+        finally:
+            td.cleanup()
+
+    def test_provider_cannot_mutate_executor_owned_context_or_observation_history(self):
+        td,root,p=temp_vessel()
+        try:
+            p.intelligence.remember(
+                kind='semantic',scope='crew',crew_id='backend-engineer',memory_key='immutable-provider-view',
+                content='README evidence remains attributable despite provider-local mutation attempts.',
+                provenance={'mission_id':'M-immutable-view'},
+            )
+            provider=MutatingInputProvider()
+            p.executor.cognition_provider=provider
+            result=p.command('Inspect README evidence',mode=MissionMode.inspect,crew_id='backend-engineer')
+            self.assertEqual(result['status'],'completed')
+            self.assertEqual(len(provider.snapshots),2)
+            self.assertIn('GroX Operational Binding',provider.snapshots[0]['craft_headings'])
+            self.assertIn('GroX Operational Binding',provider.snapshots[1]['craft_headings'])
+            self.assertGreaterEqual(provider.snapshots[0]['memory_count'],1)
+            self.assertEqual(provider.snapshots[1]['memory_count'],provider.snapshots[0]['memory_count'])
+            self.assertEqual(provider.snapshots[0]['observation_count'],0)
+            self.assertEqual(provider.snapshots[1]['observation_count'],1)
+            mission=p.store.mission(result['mission_id'])
+            cognition=_evidence_content(next(e for e in mission['evidence'] if e['kind']=='crew_cognition'))
+            self.assertEqual(cognition['observation_count'],1)
         finally:
             td.cleanup()
 

--- a/tests/integration/test_living_company.py
+++ b/tests/integration/test_living_company.py
@@ -3,7 +3,7 @@ import unittest
 
 from grox.contracts import MissionMode, TourResult
 from grox.pilot import PilotGorXu
-from tests._support import temp_vessel
+from tests._support import add_synthetic_crew, temp_vessel
 
 
 EXPERIENCED_BACKEND = {
@@ -27,8 +27,8 @@ def experienced_vessel():
     td,root,_=temp_vessel()
     original=dict(EXPERIENCED_BACKEND)
     original['crew_id']='backend-engineer'; original['title']='Backend Engineer'
-    (root/'configs/crew/dossiers/backend-engineer.json').write_text(json.dumps(original))
-    (root/'configs/crew/dossiers/backend-engineer-b.json').write_text(json.dumps(EXPERIENCED_BACKEND))
+    add_synthetic_crew(root,original)
+    add_synthetic_crew(root,EXPERIENCED_BACKEND)
     return td,root,PilotGorXu(root,reasoner=None)
 
 

--- a/tests/integration/test_mission_graph.py
+++ b/tests/integration/test_mission_graph.py
@@ -4,7 +4,7 @@ import unittest
 from grox.contracts import TourResult
 from grox.pilot import PilotGorXu
 from grox.runtime.executor import CrewExecutor
-from tests._support import temp_vessel
+from tests._support import add_synthetic_crew, temp_vessel
 
 EXTRA_CREW=[
     {'crew_id':'researcher','division':'intelligence','title':'Researcher','capabilities':['repo_read','analysis'], 'tags':['research','evidence']},
@@ -17,7 +17,7 @@ EXTRA_CREW=[
 def graph_vessel():
     td,root,_=temp_vessel()
     for d in EXTRA_CREW:
-        (root/'configs/crew/dossiers'/f"{d['crew_id']}.json").write_text(json.dumps(d))
+        add_synthetic_crew(root,d)
     return td,root,PilotGorXu(root,reasoner=None)
 
 

--- a/tests/unit/test_crew_cognition_performance.py
+++ b/tests/unit/test_crew_cognition_performance.py
@@ -1,0 +1,41 @@
+import unittest
+
+from grox.contracts import Evidence, RiskClass, TourResult
+from tests._support import temp_vessel
+
+
+class CrewCognitionPerformanceTests(unittest.TestCase):
+    def test_cognition_and_craft_bookkeeping_do_not_inflate_evidence_quality(self):
+        td,root,p=temp_vessel()
+        try:
+            operational=[
+                Evidence('inventory',{'count':1}),
+                Evidence('test_run',{'returncode':0}),
+            ]
+            baseline=TourResult('ORD-baseline','backend-engineer','completed','baseline',list(operational))
+            augmented=TourResult(
+                'ORD-augmented','backend-engineer','completed','augmented',
+                list(operational)+[
+                    Evidence('craft_selection',{'craft_sha256':'a'*64}),
+                    Evidence('crew_cognition_observation',{'action':'fs_read','sha256':'b'*64}),
+                    Evidence('crew_cognition',{'provider':'fake','work_product':'bounded'}),
+                ],
+            )
+            p.intelligence.record_performance(
+                crew_id='backend-engineer',mission_id='MSN-baseline',order_id='ORD-baseline',
+                task_class='baseline-quality',result=baseline,latency_ms=1.0,risk=RiskClass.low,
+            )
+            p.intelligence.record_performance(
+                crew_id='backend-engineer',mission_id='MSN-augmented',order_id='ORD-augmented',
+                task_class='augmented-quality',result=augmented,latency_ms=1.0,risk=RiskClass.low,
+            )
+            baseline_row=p.store.performance_history('backend-engineer','baseline-quality')[0]
+            augmented_row=p.store.performance_history('backend-engineer','augmented-quality')[0]
+            self.assertEqual(baseline_row['evidence_quality'],augmented_row['evidence_quality'])
+            self.assertAlmostEqual(baseline_row['evidence_quality'],0.916667,places=6)
+        finally:
+            td.cleanup()
+
+
+if __name__=='__main__':
+    unittest.main()

--- a/tests/unit/test_selective_craft_context.py
+++ b/tests/unit/test_selective_craft_context.py
@@ -122,6 +122,10 @@ Pilot GorXu remains sole operational orchestrator and Mission authority remains 
             self.assertEqual(meta['craft']['craft_sha256'], order.parameters['_craft_context_meta']['craft_sha256'])
             pilot.store.save_order(order)
             self.assertTrue(order.sealed)
+            result=pilot.executor.execute(order)
+            craft_evidence=[item for item in result.evidence if item.kind=='craft_selection']
+            self.assertEqual(len(craft_evidence),1)
+            self.assertEqual(craft_evidence[0].content['craft_sha256'],meta['craft']['craft_sha256'])
             with self.assertRaises(AttributeError):
                 order.parameters = {'_craft_context': []}
         finally:
@@ -146,6 +150,9 @@ Pilot GorXu remains sole operational orchestrator and Mission authority remains 
             self.assertNotIn('_craft_context',order.parameters)
             self.assertNotIn('_craft_context_meta',order.parameters)
             self.assertIsNone(meta['craft'])
+            pilot.store.save_order(order)
+            result=pilot.executor.execute(order)
+            self.assertFalse(any(item.kind=='craft_selection' for item in result.evidence))
         finally:
             td.cleanup()
 

--- a/tests/unit/test_selective_craft_context.py
+++ b/tests/unit/test_selective_craft_context.py
@@ -61,6 +61,27 @@ Pilot GorXu remains sole operational orchestrator and Mission authority remains 
         self.assertFalse(selected['full_card_injected'])
         self.assertEqual(selected['freshness_policy'], 'live-verification-required')
         self.assertEqual(selected['source_revision'], 'abc123')
+        by_heading={item['heading']:item['content'] for item in selected['selected_sections']}
+        self.assertEqual(by_heading['Purpose'],'## Purpose\n\nReview systems safely.')
+        self.assertEqual(by_heading['Safety Boundaries'],'## Safety Boundaries\n\nNever widen authority or mutate without explicit Repair permission.')
+        self.assertEqual(by_heading['GroX Operational Binding'],'## GroX Operational Binding\n\nPilot GorXu remains sole operational orchestrator and Mission authority remains deterministic.')
+
+    def test_mandatory_context_fails_closed_instead_of_being_truncated(self):
+        card='''## Purpose\n\n%s\n\n## Safety Boundaries\n\n%s\n\n## GroX Operational Binding\n\n%s\n''' % ('p'*180,'s'*180,'g'*180)
+        with self.assertRaisesRegex(ValueError,'complete mandatory safety context'):
+            select_craft_context(card,'Inspect safely',max_sections=6,max_chars=256)
+
+    def test_all_canonical_deep_cards_fit_complete_mandatory_context_at_default_budget(self):
+        cards=sorted((ROOT/'configs/crew/specialists').glob('*.md'))
+        self.assertEqual(len(cards),82)
+        for path in cards:
+            with self.subTest(card=path.name):
+                selected=select_craft_context(path.read_text(encoding='utf-8'),'Inspect Vessel safety and operational readiness')
+                headings=set(selected['selected_headings'])
+                self.assertIn('Purpose',headings)
+                self.assertIn('Safety Boundaries',headings)
+                self.assertIn('GroX Operational Binding',headings)
+                self.assertLessEqual(selected['selected_chars'],4500)
 
     def test_real_deep_card_selection_is_deterministic_and_bounded(self):
         card = (ROOT / 'configs/crew/specialists/code-reviewer.md').read_text(encoding='utf-8')
@@ -103,6 +124,28 @@ Pilot GorXu remains sole operational orchestrator and Mission authority remains 
             self.assertTrue(order.sealed)
             with self.assertRaises(AttributeError):
                 order.parameters = {'_craft_context': []}
+        finally:
+            td.cleanup()
+
+    def test_non_inspect_order_keeps_memory_context_without_deep_craft_injection(self):
+        td, root, pilot = temp_vessel()
+        try:
+            order = MissionOrder.new(
+                'MSN-no-craft-verify',
+                'Verify backend evidence',
+                'Verify backend evidence',
+                MissionMode.verify,
+                'code-reviewer',
+                required_capabilities=['repo_read','verify'],
+                allowed_actions=['fs_list','fs_read','test_run'],
+                forbidden_actions=['fs_write'],
+                scope=['.'],
+            )
+            meta=pilot.intelligence.inject_order_context(order,order.objective)
+            self.assertIn('_memory_context',order.parameters)
+            self.assertNotIn('_craft_context',order.parameters)
+            self.assertNotIn('_craft_context_meta',order.parameters)
+            self.assertIsNone(meta['craft'])
         finally:
             td.cleanup()
 

--- a/tests/unit/test_selective_craft_context.py
+++ b/tests/unit/test_selective_craft_context.py
@@ -1,0 +1,111 @@
+import unittest
+from pathlib import Path
+
+from grox.contracts import MissionMode, MissionOrder
+from grox.craft_context import select_craft_context
+from tests._support import temp_vessel
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class SelectiveCraftContextTests(unittest.TestCase):
+    def test_relevant_section_and_mandatory_boundaries_are_selected(self):
+        card = '''---
+name: security-reviewer
+freshness_policy: live-verification-required
+source_revision: abc123
+---
+
+## Identity
+
+Security reviewer identity.
+
+## Purpose
+
+Review systems safely.
+
+## Responsibilities
+
+General review responsibilities.
+
+## Database Protocol
+
+Inspect query plans and schema migrations.
+
+## Security Protocol
+
+Trace authentication, authorization, secret handling, and trust boundaries.
+
+## Safety Boundaries
+
+Never widen authority or mutate without explicit Repair permission.
+
+## GroX Operational Binding
+
+Pilot GorXu remains sole operational orchestrator and Mission authority remains deterministic.
+'''
+        selected = select_craft_context(
+            card,
+            'Inspect authentication authorization and secret handling',
+            max_sections=4,
+            max_chars=1800,
+        )
+        headings = selected['selected_headings']
+        self.assertIn('Purpose', headings)
+        self.assertIn('Safety Boundaries', headings)
+        self.assertIn('GroX Operational Binding', headings)
+        self.assertIn('Security Protocol', headings)
+        self.assertNotIn('Database Protocol', headings)
+        self.assertLessEqual(selected['selected_chars'], 1800)
+        self.assertFalse(selected['full_card_injected'])
+        self.assertEqual(selected['freshness_policy'], 'live-verification-required')
+        self.assertEqual(selected['source_revision'], 'abc123')
+
+    def test_real_deep_card_selection_is_deterministic_and_bounded(self):
+        card = (ROOT / 'configs/crew/specialists/code-reviewer.md').read_text(encoding='utf-8')
+        objective = 'Review AI-authored code for dependency provenance security regressions and test quality'
+        first = select_craft_context(card, objective, max_sections=6, max_chars=3200)
+        second = select_craft_context(card, objective, max_sections=6, max_chars=3200)
+        self.assertEqual(first, second)
+        self.assertLessEqual(first['selected_chars'], 3200)
+        self.assertLessEqual(len(first['selected_sections']), 6)
+        self.assertLess(first['selected_chars'], first['card_chars'])
+        self.assertFalse(first['full_card_injected'])
+        self.assertTrue(first['truncated'])
+        self.assertIn('AI-Authored Code Review Protocol', first['selected_headings'])
+        self.assertIn('Safety Boundaries', first['selected_headings'])
+        self.assertIn('GroX Operational Binding', first['selected_headings'])
+
+    def test_living_company_injects_bounded_craft_alongside_memory_before_sealing(self):
+        td, root, pilot = temp_vessel()
+        try:
+            order = MissionOrder.new(
+                'MSN-craft-test',
+                'Inspect backend code',
+                'Inspect backend code',
+                MissionMode.inspect,
+                'backend-engineer',
+                required_capabilities=['repo_read'],
+                allowed_actions=['fs_list', 'fs_read'],
+                forbidden_actions=['fs_write'],
+                scope=['.'],
+            )
+            meta = pilot.intelligence.inject_order_context(order, order.objective)
+            self.assertIn('_memory_context', order.parameters)
+            self.assertIn('_craft_context', order.parameters)
+            self.assertIn('_craft_context_meta', order.parameters)
+            self.assertGreater(len(order.parameters['_craft_context']), 0)
+            self.assertLessEqual(order.parameters['_craft_context_meta']['selected_chars'], pilot.intelligence.craft_chars)
+            self.assertFalse(order.parameters['_craft_context_meta']['full_card_injected'])
+            self.assertEqual(meta['craft']['craft_sha256'], order.parameters['_craft_context_meta']['craft_sha256'])
+            pilot.store.save_order(order)
+            self.assertTrue(order.sealed)
+            with self.assertRaises(AttributeError):
+                order.parameters = {'_craft_context': []}
+        finally:
+            td.cleanup()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Scope

Implements issue #73 as a bounded post-Apex evolution of Standing Crew competence context and Inspect execution. This is **not A8**, not a release decision, and not a new command layer.

### Inspect-only selective specialist craft

- reads only the routed active Crew member's canonical craft card;
- applies selective deep craft only to **Inspect** Orders; Verify, Repair, and Execute retain their existing task/memory context without unused deep craft;
- deterministically selects Mission-relevant sections under default **6-section / 4,500-character** bounds;
- requires Purpose, Safety Boundaries, and GroX Operational Binding to fit **in full** when present; insufficient mandatory-context budget fails closed rather than truncating safety/operational binding;
- records full-card SHA-256 plus source revision/freshness metadata;
- emits explicit `craft_selection` evidence during Inspect execution, even when no cognition provider is configured;
- never injects a complete deep craft card by default;
- seals selected craft alongside existing bounded Crew memory before Order persistence.

### Provider-neutral read-only Crew cognition seam

When a Crew cognition provider is separately supplied, Inspect tours may consume a sanitized copy of the sealed Order envelope, selected craft, bounded memory, and governed observations. The provider may request only `fs_list`, `fs_read`, or `test_run`, and every request still traverses the existing Mission Order + Tool Gateway boundary.

Hard default bounds:

- **4** cognitive steps per tour;
- **1** cognitive `test_run` per tour;
- **8,000** observation characters;
- **4,000** final work-product characters.

Mutating requests and scope/root escapes fail closed. Known recoverable provider/contract failure degrades to the existing deterministic Inspect executor without authority widening. Provider-facing Order/craft/memory/observation structures are copied per call, so provider-local mutation cannot alter executor-owned authority or prior observation history. Governed observations remain evidenced even if the provider later degrades; persistent read-observation evidence retains bounded metadata/hashes rather than raw file contents.

Verify, Repair, and Execute remain on their existing deterministic paths. The cognition seam cannot self-route, issue Orders, create capability, lower risk, grant Repair authority, or satisfy verifier independence.

### Routing neutrality

Craft/cognition bookkeeping evidence (`craft_selection`, `crew_cognition`, observation/degradation/denial records) is explicitly excluded from Living Company evidence-quality scoring. Adding the cognition seam therefore cannot improve Crew routing history merely by creating more evidence kinds; a regression proves identical operational evidence receives the same quality score with or without cognition metadata.

### Controlled qualification only

The PR uses deterministic/fake cognition providers in CI to prove the provider-neutral seam. **It does not claim that a live project/session model or external provider is operational for Standing Crew.** Live model-backed Crew cognition requires a separate operational qualification.

## Preserved architecture

**Commander → Pilot GorXu → Divisions → Standing Crew** remains unchanged.

- GorXu remains sole operational orchestrator.
- Mission Order and Tool Gateway remain authority-bearing boundaries.
- Craft, memory, provider output, confidence, and prior performance remain advisory competence context.
- Explicit Repair remains the mutation authority path.
- Independent verifier separation and Mission outcome truthfulness remain intact.
- Standing Crew remains 82.
- Package/release remains 0.8.0 / v0.8.0.
- No A8 is created or implied.

## Validation history

The branch preserved red evidence and corrected blockers rather than bypassing them:

- initial Slice 1 CI exposed synthetic-fixture craft gaps and mandatory-context budget starvation; production craft lookup stayed fail-closed while fixtures/budgeting were corrected;
- first Slice 2 CI exposed test-harness assertion errors; assertions were corrected without weakening runtime behavior;
- independent review found provider-input mutability and loss of pre-degradation cognitive observation evidence; both were repaired and regression-covered;
- boundedness review added the single cognitive test-run ceiling and bounded work-product ceiling;
- architectural review narrowed deep craft from every Order to Inspect-only and strengthened mandatory safety/binding from budget reservation to full-section fail-closed preservation;
- observability review promoted craft attribution to explicit `craft_selection` execution evidence;
- routing review found that new bookkeeping evidence would otherwise inflate Living Company evidence-quality scoring; cognition/context bookkeeping is now excluded and routing-neutrality is regression-covered.

## Final qualification gate

Exact final source head: `db83c557e378e6e3a3471318b50e6b82a5d68641`.

Canonical GroX CI run `32166921610` / run 232 completed successfully across all five required jobs on that exact head, including the full Python 3.12 Health, regression, mutation, and integrated Post-Apex qualification chain.

Controlled-provider CI must not be interpreted as live-model qualification.

Closes #73 after canonical merge and verification.