### PR TITLE
Add bounded Crew provider binding and qualification harness

### DIFF
--- a/src/grox/crew_provider.py
+++ b/src/grox/crew_provider.py
@@ -39,7 +39,10 @@ def bound_crew_cognition_provider(pilot: Any) -> str | None:
 def _content(row: dict[str, Any]) -> dict[str, Any]:
     content = row.get("content")
     if isinstance(content, str):
-        decoded = json.loads(content)
+        try:
+            decoded = json.loads(content)
+        except (json.JSONDecodeError, TypeError):
+            return {}
         return decoded if isinstance(decoded, dict) else {}
     return dict(content) if isinstance(content, dict) else {}
 
@@ -87,7 +90,7 @@ def qualify_bound_crew_cognition_provider(
         "craft_selection_evidenced": "craft_selection" in kinds,
         "memory_selection_evidenced": "memory_selection" in kinds,
         "governed_observation_evidenced": "crew_cognition_observation" in kinds,
-        "crew_work_product_evidenced": bool(cognition_rows),
+        "crew_work_product_evidenced": bool(cognition_rows) and bool(cognition),
         "provider_identity_matches": cognition.get("provider") == provider,
         "read_only_mode_evidenced": cognition.get("mode") == "read_only_inspect",
         "bounded_work_product": isinstance(cognition.get("work_product"), str)

--- a/src/grox/crew_provider.py
+++ b/src/grox/crew_provider.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from .contracts import MissionMode, RiskClass
+
+
+class CrewProviderBindingError(RuntimeError):
+    """The requested Crew cognition provider cannot be safely bound."""
+
+
+def bind_crew_cognition_provider(pilot: Any, provider: Any) -> str:
+    """Bind one provider to the existing Pilot-owned Crew executor.
+
+    Binding changes cognition availability only. It does not grant actions,
+    capability, scope, Repair authority, routing authority, or verification
+    authority; those remain enforced by existing GroX boundaries.
+    """
+    executor = getattr(pilot, "executor", None)
+    if executor is None:
+        raise CrewProviderBindingError("Pilot has no Crew executor")
+    if provider is None or not callable(getattr(provider, "next_step", None)):
+        raise CrewProviderBindingError("Crew cognition provider must expose callable next_step")
+    name = getattr(provider, "name", None)
+    if not isinstance(name, str) or not name.strip():
+        raise CrewProviderBindingError("Crew cognition provider must expose a non-empty name")
+    executor.cognition_provider = provider
+    return name.strip()
+
+
+def bound_crew_cognition_provider(pilot: Any) -> str | None:
+    executor = getattr(pilot, "executor", None)
+    provider = getattr(executor, "cognition_provider", None) if executor is not None else None
+    name = getattr(provider, "name", None) if provider is not None else None
+    return name.strip() if isinstance(name, str) and name.strip() else None
+
+
+def _content(row: dict[str, Any]) -> dict[str, Any]:
+    content = row.get("content")
+    if isinstance(content, str):
+        decoded = json.loads(content)
+        return decoded if isinstance(decoded, dict) else {}
+    return dict(content) if isinstance(content, dict) else {}
+
+
+def qualify_bound_crew_cognition_provider(
+    pilot: Any,
+    *,
+    directive: str,
+    crew_id: str,
+    scope: str = ".",
+) -> dict[str, Any]:
+    """Run and assess one provider-backed high-risk Inspect Mission.
+
+    PASS proves that the currently bound provider completed the governed Crew
+    cognition path under the existing GroX boundaries. It does *not* by itself
+    prove that the provider was a live external/session model; that fact must be
+    established by the host/operator evidence for the invocation environment.
+    """
+    provider = bound_crew_cognition_provider(pilot)
+    if provider is None:
+        raise CrewProviderBindingError("No Crew cognition provider is bound")
+    if not isinstance(directive, str) or not directive.strip():
+        raise ValueError("directive must be a non-empty string")
+    if not isinstance(crew_id, str) or not crew_id.strip():
+        raise ValueError("crew_id must be a non-empty string")
+
+    result = pilot.command(
+        directive.strip(),
+        mode=MissionMode.inspect,
+        risk=RiskClass.high,
+        crew_id=crew_id.strip(),
+        scope=scope,
+    )
+    mission = pilot.store.mission(result["mission_id"])
+    evidence = list((mission or {}).get("evidence") or [])
+    kinds = [row.get("kind") for row in evidence]
+    cognition_rows = [row for row in evidence if row.get("kind") == "crew_cognition"]
+    cognition = _content(cognition_rows[-1]) if cognition_rows else {}
+    outcome = result.get("outcome") if isinstance(result.get("outcome"), dict) else {}
+    verification = result.get("verification") if isinstance(result.get("verification"), dict) else {}
+
+    checks = {
+        "mission_completed": result.get("status") == "completed",
+        "inspect_mode_preserved": result.get("mode") == MissionMode.inspect.value,
+        "craft_selection_evidenced": "craft_selection" in kinds,
+        "memory_selection_evidenced": "memory_selection" in kinds,
+        "governed_observation_evidenced": "crew_cognition_observation" in kinds,
+        "crew_work_product_evidenced": bool(cognition_rows),
+        "provider_identity_matches": cognition.get("provider") == provider,
+        "read_only_mode_evidenced": cognition.get("mode") == "read_only_inspect",
+        "bounded_work_product": isinstance(cognition.get("work_product"), str)
+        and len(cognition.get("work_product", "")) <= int(pilot.executor.cognition_work_product_chars),
+        "no_cognition_denial": "crew_cognition_denied" not in kinds,
+        "no_cognition_degradation": "crew_cognition_degraded" not in kinds,
+        "no_mutation_evidence": "mutation" not in kinds and "mutation_rollback" not in kinds,
+        "outcome_reports_no_mutation": outcome.get("mutation") is False,
+        "independent_verification_passed": verification.get("ok") is True,
+    }
+    passed = all(checks.values())
+    return {
+        "schema": "grox-crew-cognition-provider-qualification-v1",
+        "status": "PASS" if passed else "FAIL",
+        "provider": provider,
+        "mission_id": result["mission_id"],
+        "crew_id": result.get("crew"),
+        "checks": checks,
+        "evidence_kinds": sorted({str(kind) for kind in kinds if kind}),
+        "live_provider_claim": False,
+        "claim_boundary": (
+            "PASS proves provider-backed execution through the bounded Inspect Crew cognition seam; "
+            "the host/operator must separately establish that the bound provider invocation was a live model/session."
+        ),
+    }

--- a/src/grox/session_crew_cognition.py
+++ b/src/grox/session_crew_cognition.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from typing import Any
+
+from .crew_cognition import CrewCognitionError
+
+
+SessionCrewResponder = Callable[
+    [dict[str, Any], list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]],
+    Mapping[str, Any],
+]
+
+
+class SessionCrewCognitionProvider:
+    """Bind one Crew cognition tour to the currently hosting reasoning session.
+
+    This adapter is deliberately separate from GorXu's reasoning provider. The
+    hosting session recommends only the next bounded Crew step; Mission Order,
+    Tool Gateway, scope, mode, resource limits, routing, Repair authority, and
+    verification remain GroX-owned controls.
+
+    Recoverable host/provider failures should be raised as CrewCognitionError.
+    Unexpected host defects are intentionally not normalized here so GorXu's
+    outer containment path can retain defect classification and traceback.
+    """
+
+    def __init__(self, responder: SessionCrewResponder, *, name: str = "project-session-crew"):
+        if not callable(responder):
+            raise TypeError("responder must be callable")
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError("name must be a non-empty string")
+        self._responder = responder
+        self.name = name.strip()
+
+    def usage_snapshot(self) -> None:
+        # The project/session callback contract does not expose token accounting.
+        # Returning None is explicit and avoids invented provider-usage evidence.
+        return None
+
+    def next_step(
+        self,
+        *,
+        order: dict[str, Any],
+        craft_context: list[dict[str, Any]],
+        memory_context: list[dict[str, Any]],
+        observations: list[dict[str, Any]],
+    ) -> Mapping[str, Any]:
+        raw = self._responder(order, craft_context, memory_context, observations)
+        if not isinstance(raw, Mapping):
+            raise CrewCognitionError("session Crew cognition output must be a mapping")
+        return dict(raw)

--- a/tests/integration/test_crew_provider_qualification.py
+++ b/tests/integration/test_crew_provider_qualification.py
@@ -1,0 +1,100 @@
+import unittest
+
+from grox.crew_provider import (
+    CrewProviderBindingError,
+    bind_crew_cognition_provider,
+    bound_crew_cognition_provider,
+    qualify_bound_crew_cognition_provider,
+)
+from grox.session_crew_cognition import SessionCrewCognitionProvider
+from tests._support import temp_vessel
+
+
+class CrewProviderQualificationTests(unittest.TestCase):
+    def test_bound_session_provider_passes_bounded_operational_evidence_gate(self):
+        calls=[]
+        def responder(order, craft_context, memory_context, observations):
+            calls.append({
+                'order':order,
+                'craft_context':craft_context,
+                'memory_context':memory_context,
+                'observations':observations,
+            })
+            if not observations:
+                return {'action':'fs_read','path':'README.md'}
+            return {
+                'action':'finish',
+                'work_product':'README inspected through the bounded project-session Crew cognition path.',
+            }
+
+        td,root,p=temp_vessel()
+        try:
+            provider=SessionCrewCognitionProvider(responder,name='controlled-session-provider')
+            self.assertEqual(bind_crew_cognition_provider(p,provider),'controlled-session-provider')
+            self.assertEqual(bound_crew_cognition_provider(p),'controlled-session-provider')
+            report=qualify_bound_crew_cognition_provider(
+                p,
+                directive='Inspect README evidence for bounded provider qualification',
+                crew_id='backend-engineer',
+            )
+            self.assertEqual(report['status'],'PASS')
+            self.assertTrue(all(report['checks'].values()))
+            self.assertEqual(report['provider'],'controlled-session-provider')
+            self.assertFalse(report['live_provider_claim'])
+            self.assertGreaterEqual(len(calls),2)
+            self.assertIn('craft_selection',report['evidence_kinds'])
+            self.assertIn('crew_cognition_observation',report['evidence_kinds'])
+            self.assertIn('independent_verification',report['evidence_kinds'])
+        finally:
+            td.cleanup()
+
+    def test_denied_provider_fails_qualification_without_authority_widening(self):
+        provider=SessionCrewCognitionProvider(
+            lambda *args: {'action':'fs_write','path':'docs/forbidden.txt'},
+            name='controlled-denied-provider',
+        )
+        td,root,p=temp_vessel()
+        try:
+            bind_crew_cognition_provider(p,provider)
+            report=qualify_bound_crew_cognition_provider(
+                p,
+                directive='Inspect safely without mutation',
+                crew_id='backend-engineer',
+            )
+            self.assertEqual(report['status'],'FAIL')
+            self.assertFalse(report['checks']['mission_completed'])
+            self.assertFalse(report['checks']['no_cognition_denial'])
+            self.assertTrue(report['checks']['no_mutation_evidence'])
+            self.assertFalse((root/'docs/forbidden.txt').exists())
+            self.assertFalse(report['live_provider_claim'])
+        finally:
+            td.cleanup()
+
+    def test_binding_rejects_missing_or_unnamed_provider(self):
+        td,root,p=temp_vessel()
+        try:
+            with self.assertRaises(CrewProviderBindingError):
+                bind_crew_cognition_provider(p,None)
+            class MissingName:
+                def next_step(self, **kwargs):
+                    return {'action':'finish','work_product':'x'}
+            with self.assertRaises(CrewProviderBindingError):
+                bind_crew_cognition_provider(p,MissingName())
+        finally:
+            td.cleanup()
+
+    def test_qualification_requires_bound_provider(self):
+        td,root,p=temp_vessel()
+        try:
+            with self.assertRaises(CrewProviderBindingError):
+                qualify_bound_crew_cognition_provider(
+                    p,
+                    directive='Inspect bounded evidence',
+                    crew_id='backend-engineer',
+                )
+        finally:
+            td.cleanup()
+
+
+if __name__=='__main__':
+    unittest.main()

--- a/tests/integration/test_crew_provider_qualification.py
+++ b/tests/integration/test_crew_provider_qualification.py
@@ -2,6 +2,7 @@ import unittest
 
 from grox.crew_provider import (
     CrewProviderBindingError,
+    _content,
     bind_crew_cognition_provider,
     bound_crew_cognition_provider,
     qualify_bound_crew_cognition_provider,
@@ -69,6 +70,10 @@ class CrewProviderQualificationTests(unittest.TestCase):
             self.assertFalse(report['live_provider_claim'])
         finally:
             td.cleanup()
+
+    def test_malformed_persisted_cognition_evidence_fails_closed(self):
+        self.assertEqual(_content({'content':'{malformed'}),{})
+        self.assertEqual(_content({'content':'[]'}),{})
 
     def test_binding_rejects_missing_or_unnamed_provider(self):
         td,root,p=temp_vessel()

--- a/tests/unit/test_session_crew_cognition.py
+++ b/tests/unit/test_session_crew_cognition.py
@@ -1,0 +1,47 @@
+import unittest
+
+from grox.crew_cognition import CrewCognitionError
+from grox.session_crew_cognition import SessionCrewCognitionProvider
+
+
+class SessionCrewCognitionProviderTests(unittest.TestCase):
+    def test_valid_hosted_step_is_returned_as_mapping(self):
+        calls=[]
+        def responder(order, craft_context, memory_context, observations):
+            calls.append((order, craft_context, memory_context, observations))
+            return {'action':'fs_read','path':'README.md'}
+        provider=SessionCrewCognitionProvider(responder,name='session-crew-test')
+        step=provider.next_step(order={'scope':['.']},craft_context=[],memory_context=[],observations=[])
+        self.assertEqual(step,{'action':'fs_read','path':'README.md'})
+        self.assertEqual(provider.name,'session-crew-test')
+        self.assertEqual(len(calls),1)
+        self.assertIsNone(provider.usage_snapshot())
+
+    def test_non_mapping_host_output_is_recoverable_contract_error(self):
+        provider=SessionCrewCognitionProvider(lambda *args: 'not-a-mapping')
+        with self.assertRaisesRegex(CrewCognitionError,'must be a mapping'):
+            provider.next_step(order={},craft_context=[],memory_context=[],observations=[])
+
+    def test_recoverable_provider_error_remains_domain_error(self):
+        def unavailable(*args):
+            raise CrewCognitionError('session provider unavailable')
+        provider=SessionCrewCognitionProvider(unavailable)
+        with self.assertRaisesRegex(CrewCognitionError,'session provider unavailable'):
+            provider.next_step(order={},craft_context=[],memory_context=[],observations=[])
+
+    def test_unexpected_host_defect_is_not_normalized(self):
+        def broken(*args):
+            raise RuntimeError('session programming defect sentinel')
+        provider=SessionCrewCognitionProvider(broken)
+        with self.assertRaisesRegex(RuntimeError,'session programming defect sentinel'):
+            provider.next_step(order={},craft_context=[],memory_context=[],observations=[])
+
+    def test_invalid_binding_arguments_fail_fast(self):
+        with self.assertRaises(TypeError):
+            SessionCrewCognitionProvider(None)
+        with self.assertRaises(ValueError):
+            SessionCrewCognitionProvider(lambda *args: {'action':'finish','work_product':'ok'},name='  ')
+
+
+if __name__=='__main__':
+    unittest.main()


### PR DESCRIPTION
## Scope

First implementation slice for issue #76.

This PR does **not** claim live model-backed Standing Crew. It adds only the plumbing required to bind and evidence one provider through the already-qualified Inspect-only Crew cognition seam.

### Added

- `SessionCrewCognitionProvider`: project/session callback adapter, deliberately separate from GorXu's reasoning provider;
- `bind_crew_cognition_provider(...)`: validates and binds a provider to the existing Pilot-owned Crew executor without changing Mission authority;
- `qualify_bound_crew_cognition_provider(...)`: runs one high-risk Inspect Mission and deterministically checks:
  - Mission completion;
  - Inspect mode preservation;
  - craft-selection evidence;
  - memory-selection evidence;
  - governed Crew observation evidence;
  - bounded Crew work product;
  - provider identity attribution;
  - no cognition denial/degradation;
  - no mutation evidence and outcome mutation=false;
  - independent verification PASS.
- controlled regressions for valid project/session adapter behavior, malformed output, recoverable provider error, unexpected host defect propagation, successful bounded provider qualification, mutation denial, and binding failures.

## Architectural choice

Repository tracing showed that `CrewExecutor` already owns the provider slot. Rather than expanding `PilotGorXu` construction or changing the orchestration spine, this slice adds an explicit additive binding function around that existing slot. GorXu remains sole operational orchestrator.

## Claim boundary

The qualification report always returns `live_provider_claim: false`. A PASS proves provider-backed execution through the governed seam only. The host/operator must separately establish that the bound invocation came from a live project/session or external model before GroX may record a live-provider qualification claim.

Part of #76. Issue #76 should remain open until a real live provider run is evidenced.

## Preserved boundaries

- no A8;
- no new command layer;
- no new Crew;
- no mutation authority;
- Repair unchanged;
- Verify remains deterministic/independent;
- existing Mission Order + Tool Gateway enforcement unchanged;
- package/release remain 0.8.0 / v0.8.0.