### PR TITLE
Record the vendor-ceiling turning point

### DIFF
--- a/docs/history/ships-log/0060-beyond-the-vendor-ceiling.md
+++ b/docs/history/ships-log/0060-beyond-the-vendor-ceiling.md
@@ -1,0 +1,153 @@
+# Ship's Log 0060 — Beyond the Vendor Ceiling
+
+**Date:** 2026-08-20  
+**Status:** COMMANDER STRATEGIC DECISION — NCI RATIONALE RECORDED  
+**Issue:** #86  
+**Program:** Native Cognition Independence Program 001
+
+## Mission Diary
+
+GroX began this journey with a defining objective: build a persistent AI Vessel in which Pilot GorXu could become an exceptional orchestrator of a real Standing Crew while remaining the Commander's personal AI assistant.
+
+That journey produced the native command relationship:
+
+> **Commander → Pilot GorXu → Divisions → Standing Crew**
+
+GorXu became the Vessel's second-in-command, principal assistant interface, and sole operational orchestrator. The Standing Crew became real bounded operational capabilities rather than decorative personas. Mission Orders, Mission Graphs, organizational memory, evidence, independent verification, durable recovery, governed tools, Living Company routing, orchestration evaluation, and the complete A1-A7 Apex qualification path were implemented and tested. Post-Apex evolution then strengthened the Vessel further without creating another command layer.
+
+The Apex journey therefore remains foundational. Native cognition is not a departure from orchestration. It is the next step required to let that orchestration continue travelling farther.
+
+## The ceiling we reached
+
+After qualifying the Apex orchestration architecture, the next limiting dependency became clear: GroX's highest general cognition could still depend on models supplied and controlled by external vendors.
+
+Those models can be extremely capable, but the Vessel does not control their availability, pricing, subscription requirements, policies, interfaces, context limits, service changes, or continued existence. If GroX requires a vendor-hosted model merely to think at its minimum useful level, an external party can still determine how far the Vessel can travel.
+
+This is the **vendor ceiling**.
+
+The ceiling is a dependency and ownership problem, not a claim that vendor models lack capability. Their capability is valuable. The problem is allowing any one of them to become the Vessel's required pilot or sole source of cognitive energy.
+
+## Commander decision
+
+The Commander has therefore set a new strategic direction:
+
+> **No vendor will determine how far GroX can evolve, and no vendor model will remain the Vessel's sole source of cognitive energy.**
+
+GroX will build and evolve a native cognition runtime and in-house model capability that belongs to the Vessel and can provide its minimum useful cognitive operating condition locally.
+
+This does not change who pilots the ship.
+
+**Pilot GorXu remains at the helm.** GorXu remains the Commander's second-in-command, principal personal-assistant interface, and sole operational orchestrator—the operational General of the Vessel in descriptive terms. `Pilot GorXu` remains the canonical role; "General" does not create a new role or command layer.
+
+The native model is an **engine of the Vessel**, not its commander. It exists to power GorXu and authorized Crew cognition under the existing GroX authority structure.
+
+The intended relationship remains:
+
+```text
+Commander
+    ↓
+Pilot GorXu
+    ↓
+Divisions → Standing Crew
+    ↓
+GroX capabilities
+    ├── native/local cognition
+    ├── local tools and memory
+    ├── training and evaluation
+    └── optional external intelligence
+```
+
+GorXu continues to interpret Commander intent, plan work, select the smallest relevant Crew, delegate tasks, coordinate capabilities, reconcile evidence, require verification where appropriate, and synthesize outcomes for the Commander.
+
+A more capable model must therefore make GroX a stronger orchestrator and assistant. Model development must not steer GroX away from the orchestration journey that produced the Apex-qualified Vessel.
+
+## External intelligence remains aboard
+
+Native cognition independence does **not** mean abandoning vendor models.
+
+OpenAI, Anthropic, Google, and future providers remain potentially powerful resources of the Vessel. Under GorXu's orchestration they may serve as:
+
+- specialist cognitive engines for relevant Crew or Missions;
+- external knowledge and research resources;
+- consultants and second opinions;
+- coding, reasoning, or synthesis capabilities;
+- cross-checkers and challengers of local conclusions;
+- sources of additional cognitive energy when a Mission justifies the cost, privacy exposure, connectivity, and policy implications;
+- candidate teaching resources where applicable rights and provider terms permit their output to be used for training or evaluation.
+
+GorXu decides when external intelligence materially improves a Commander objective and which Crew or Mission should receive it. A vendor model does not become the Pilot merely because it is stronger at a particular task, and external intelligence inherits no GroX authority.
+
+The desired posture is therefore not **vendor-free**. It is **vendor-independent and vendor-augmented**.
+
+## The neural organism
+
+The new roadmap also recognizes a second principle:
+
+> **GroX is a neural organism that becomes progressively better at operating inside GroX.**
+
+The organism is larger than any one set of model weights. It includes GorXu orchestration, Crew craft, bounded memory, verified Mission experience, evidence, model checkpoints, training provenance, evaluations, accepted and rejected descendants, tools, persistence, and recovery.
+
+GroX may improve through collaboration among GorXu, Standing Crew, verified Mission experience, locally trained models, and optional external intelligence. That evolution remains governed.
+
+- Commander directives determine the destination.
+- GorXu orchestrates the work and remains the sole operational orchestrator.
+- Crew contribute real bounded expertise.
+- Models and tools contribute capability.
+- Evidence and independent verification constrain confidence.
+- Candidate model generations cannot self-promote or grant themselves authority.
+- Evolution cannot create an objective independent of serving the Commander.
+
+GroX evolves **to become a better personal assistant and orchestrator for the Commander**. The Commander does not exist to provide GroX with training data.
+
+## Localhost and accessibility objective
+
+The independence decision has a public consequence as well.
+
+The long-term target is that a person who clones the GroX repository can launch a useful GroX personal-assistant/orchestration Vessel on their own localhost and hardware without being required to purchase access to OpenAI, Anthropic, Google, or another commercial model provider.
+
+Paid models, network access, remote compute, and external intelligence may make the Vessel substantially stronger when available. They should be **capability multipliers**, not admission tickets.
+
+Nobody should be prevented from beginning the GroX journey solely because they cannot afford a paid AI subscription.
+
+The target minimum operating condition is therefore:
+
+> **Local GroX can reconstitute, converse with its Commander, interpret objectives, orchestrate Crew, use qualified local capabilities, preserve memory/evidence, and complete a defined useful Mission set without a mandatory paid-model dependency.**
+
+That is a roadmap target, not a current qualification claim.
+
+## Why the roadmap changed
+
+Native Cognition Independence Program 001 exists because the Apex orchestration journey succeeded far enough to reveal its next ceiling.
+
+The sequence is deliberate:
+
+1. **First, build the orchestrator.** GorXu, Divisions, Crew, Mission authority, evidence, verification, persistence, recovery, and the A1-A7 Apex path established the Vessel.
+2. **Then, expose the dependency ceiling.** Further cognitive growth remained vulnerable to vendor-controlled energy sources.
+3. **Now, build the Vessel's own engine.** GroX will own the cognition lifecycle needed for a minimum useful local operating condition.
+4. **Keep external intelligence as optional power.** GorXu may still route relevant tasks and Crew to vendor models when they materially improve the Mission.
+5. **Evolve under command.** GroX may learn from verified experience and collaboration, but Commander intent remains supreme and model evolution cannot self-authorize.
+
+The new roadmap therefore does not replace GroX's original orchestration mission. It exists to protect and extend it.
+
+## Preserved Vessel state
+
+This strategic decision changes direction, not current capability claims or command authority.
+
+- Commander retains ultimate authority.
+- GroX remains first a persistent AI personal assistant to the Commander.
+- Pilot GorXu remains second-in-command, principal assistant interface, and sole operational orchestrator.
+- Divisions and Standing Crew remain the operational organization under GorXu.
+- Capabilities, including native and vendor models, remain resources rather than command layers.
+- Mission Control remains a GroX-native subordinate advisory/policy service.
+- Mission Order + Tool Gateway remain the execution-authority boundary.
+- Independent verification remains required where policy demands it.
+- Evolution cannot self-authorize or invent independent purpose.
+- Standing Crew remain **82**.
+- package remains **0.8.0**.
+- published release remains **v0.8.0**.
+- no A8 exists or is implied.
+- NCI-1 remains the next implementation Mission.
+
+The Vessel has not abandoned the original journey.
+
+**It has decided to build its own engine so that the Pilot, the Crew, and the Commander can continue that journey without a vendor deciding where the horizon ends.**


### PR DESCRIPTION
## Scope

Historical/strategic Mission Diary entry for issue #86 from canonical `main@d05f64a1f9df9662bda0076be06696096580a0bf`.

Adds exactly:

- `docs/history/ships-log/0060-beyond-the-vendor-ceiling.md`

## Decision recorded

The entry records why Native Cognition Independence Program 001 exists after the A1-A7 Apex orchestration journey:

- GroX's original and continuing identity is a superior Crew-orchestration Vessel under **Commander → Pilot GorXu → Divisions → Standing Crew**;
- Pilot GorXu remains second-in-command, principal personal-assistant interface, and sole operational orchestrator;
- the post-Apex ceiling is dependence on vendor-controlled cognition, not a claim that vendor models lack capability;
- no vendor should determine how far GroX can evolve or remain its sole source of cognitive energy;
- GroX will build a native cognition engine/runtime and in-house model capability that powers GorXu and Crew rather than replacing GorXu;
- vendor models remain optional governed consultants, specialist engines, external knowledge/energy, cross-checkers, and candidate teaching resources where applicable terms permit;
- GorXu decides when and to which relevant Crew/Mission external intelligence is delegated;
- GroX evolution remains subordinate to Commander directives and cannot self-authorize;
- a future clone should be able to achieve a defined useful localhost personal-assistant/orchestration operating condition without a mandatory paid AI subscription;
- paid/networked intelligence remains a capability multiplier, not an admission ticket.

`General` is explicitly descriptive language for GorXu's operational leadership; the canonical role remains **Pilot GorXu** and no new command layer is introduced.

## Boundaries

Documentation/history only. No README/Roadmap/Progress Tracker truth duplication, runtime change, model activation, Crew change, authority widening, package/release change, Apex-stage change, or A8. NCI-1 remains the next implementation Mission.

Closes #86 after canonical merge and exact-source verification.