### PR TITLE
NCI-1A: establish installed workspace commissioning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,31 @@ jobs:
           /tmp/grox-wheel-env/bin/python -m grox.cli status | tee /tmp/grox-wheel-status.txt
           grep -q 'Standing Crew: 82' /tmp/grox-wheel-status.txt
           grep -q "Vessel root: $GITHUB_WORKSPACE" /tmp/grox-wheel-status.txt
-      - name: Unbound installed CLI fails closed
+      - name: Installed CLI commissions workspace outside checkout
+        run: |
+          rm -rf /tmp/grox-user-config /tmp/grox-user-vessel
+          (cd /tmp && /tmp/grox-wheel-env/bin/python -m grox.cli init \
+            --workspace /tmp/grox-user-vessel \
+            --config-dir /tmp/grox-user-config \
+            --non-interactive \
+            --json) | tee /tmp/grox-init.json
+          test -f /tmp/grox-user-vessel/.grox/workspace.json
+          test -f /tmp/grox-user-config/workspace.json
+          (cd /tmp && /tmp/grox-wheel-env/bin/python -m grox.cli workspace \
+            --config-dir /tmp/grox-user-config \
+            --json) | tee /tmp/grox-workspace.json
+          /tmp/grox-wheel-env/bin/python - <<'PY'
+          import json
+          from pathlib import Path
+          initialized = json.loads(Path('/tmp/grox-init.json').read_text())
+          reported = json.loads(Path('/tmp/grox-workspace.json').read_text())
+          assert initialized['status'] == 'created', initialized
+          assert initialized['workspace'] == '/tmp/grox-user-vessel', initialized
+          assert reported['configured'] is True, reported
+          assert reported['commissioned'] is True, reported
+          assert reported['workspace'] == '/tmp/grox-user-vessel', reported
+          PY
+      - name: Unbound operational CLI still fails closed
         run: |
           set +e
           output=$(cd /tmp && /tmp/grox-wheel-env/bin/python -m grox.cli status 2>&1)

--- a/src/grox/cli.py
+++ b/src/grox/cli.py
@@ -4,13 +4,22 @@ from pathlib import Path
 from .pilot import PilotGorXu
 from .contracts import MissionMode, RiskClass
 from .health import VesselHealth
+from .installation import (
+    InstallationError,
+    commission_workspace,
+    default_workspace,
+    workspace_status,
+)
 from .persistence import PersistenceManager
 from .reconstitution import ReconstitutionPlanner
 from .vessel import resolve_vessel_root
 
-ROOT=resolve_vessel_root(module_file=__file__)
 
-def pilot(): return PilotGorXu(ROOT)
+def vessel_root():
+    return resolve_vessel_root(module_file=__file__)
+
+
+def pilot(): return PilotGorXu(vessel_root())
 
 def dump(x): print(json.dumps(x,indent=2,default=str))
 
@@ -25,7 +34,8 @@ def status(p):
     if ms: print(f"Last mission: {ms[0]['mission_id']} [{ms[0]['status']}] {ms[0]['directive']}")
 
 def health(json_output=False):
-    report=VesselHealth(ROOT).collect()
+    root=vessel_root()
+    report=VesselHealth(root).collect()
     if json_output:
         dump(report.to_dict()); return
     print(f"GroX Vessel health: {report.disposition}")
@@ -36,7 +46,8 @@ def health(json_output=False):
         if check.recommendation: print(f"  recommendation: {check.recommendation}")
 
 def reconstitution_plan(json_output=False,fresh_host=False,source_changed=False):
-    report=VesselHealth(ROOT).collect()
+    root=vessel_root()
+    report=VesselHealth(root).collect()
     plan=ReconstitutionPlanner().plan(report,fresh_host=fresh_host,source_changed=source_changed)
     if json_output:
         dump(plan.to_dict()); return
@@ -46,6 +57,36 @@ def reconstitution_plan(json_output=False,fresh_host=False,source_changed=False)
     for reason in plan.reasons: print(f"- {reason}")
     print("Load surfaces:")
     for surface in plan.load_surfaces: print(f"- {surface}")
+
+def init_workspace(workspace=None,config_dir=None,non_interactive=False,json_output=False):
+    selected=Path(workspace).expanduser() if workspace else None
+    if selected is None and not non_interactive:
+        suggested=default_workspace()
+        response=input(f"Where should GroX establish its dedicated workspace?\n[{suggested}]: ").strip()
+        selected=Path(response).expanduser() if response else suggested
+    result=commission_workspace(selected,config_dir=Path(config_dir).expanduser() if config_dir else None)
+    if json_output:
+        dump(result.to_dict()); return
+    print(f"GroX workspace foundation: {result.status.upper()}")
+    print(f"Workspace: {result.workspace}")
+    print(f"Host binding: {result.config_file}")
+    print(f"Marker: {result.marker_file}")
+    if result.created_directories:
+        print(f"Created directories: {', '.join(result.created_directories)}")
+    else:
+        print("Created directories: none (existing commissioned foundation)")
+    print("Operational Pilot startup still requires a valid GroX Vessel source binding in NCI-1A.")
+
+def show_workspace(config_dir=None,json_output=False):
+    report=workspace_status(config_dir=Path(config_dir).expanduser() if config_dir else None)
+    if json_output:
+        dump(report); return
+    state="COMMISSIONED" if report['commissioned'] else "NOT COMMISSIONED"
+    print(f"GroX workspace: {state}")
+    print(f"Workspace: {report['workspace']}")
+    print(f"Default workspace: {report['default_workspace']}")
+    print(f"Host binding: {report['config_file']}")
+    print(f"Marker: {report['marker_file']}")
 
 def bridge(p):
     print("GroX Bridge online. Pilot GorXu standing by. /help for commands; /exit to leave.")
@@ -70,6 +111,8 @@ def bridge(p):
 def main(argv=None):
     ap=argparse.ArgumentParser(prog='grox'); sp=ap.add_subparsers(dest='cmd')
     sp.add_parser('status'); sp.add_parser('roster'); sp.add_parser('missions'); sp.add_parser('bridge')
+    init=sp.add_parser('init'); init.add_argument('--workspace'); init.add_argument('--config-dir'); init.add_argument('--non-interactive',action='store_true'); init.add_argument('--json',action='store_true',dest='json_output')
+    ws=sp.add_parser('workspace'); ws.add_argument('--config-dir'); ws.add_argument('--json',action='store_true',dest='json_output')
     he=sp.add_parser('health'); he.add_argument('--json',action='store_true',dest='json_output')
     rp=sp.add_parser('reconstitution-plan'); rp.add_argument('--json',action='store_true',dest='json_output'); rp.add_argument('--fresh-host',action='store_true'); rp.add_argument('--source-changed',action='store_true')
     sh=sp.add_parser('show'); sh.add_argument('mission_id')
@@ -80,26 +123,31 @@ def main(argv=None):
     sv=sp.add_parser('verify-snapshot'); sv.add_argument('path')
     sr=sp.add_parser('restore-snapshot'); sr.add_argument('path'); sr.add_argument('--confirm',action='store_true')
     ns=ap.parse_args(argv)
-    if ns.cmd=='health': health(ns.json_output); return
-    if ns.cmd=='reconstitution-plan': reconstitution_plan(ns.json_output,ns.fresh_host,ns.source_changed); return
-    if ns.cmd=='snapshot':
-        pm=PersistenceManager(ROOT); dump(pm.create_snapshot(label=ns.label,output=Path(ns.out) if ns.out else None).to_dict()); return
-    if ns.cmd=='verify-snapshot':
-        pm=PersistenceManager(ROOT); dump(pm.verify_snapshot(Path(ns.path)).to_dict()); return
-    if ns.cmd=='restore-snapshot':
-        pm=PersistenceManager(ROOT); dump(pm.restore_snapshot(Path(ns.path),confirm=ns.confirm)); return
-    p=pilot()
-    if ns.cmd in (None,'bridge'): bridge(p); return
-    if ns.cmd=='status': status(p); return
-    if ns.cmd=='roster':
-        states={x['crew_id']:x for x in p.store.crew_states()}
-        for d in p.roster.all(): print(f"{d.crew_id:30} {d.division:14} {states[d.crew_id]['status']:8} tours={states[d.crew_id]['tours']} caps={','.join(sorted(d.capabilities))}")
-    elif ns.cmd=='missions': dump(p.store.recent_missions())
-    elif ns.cmd=='show': dump(p.store.mission(ns.mission_id))
-    elif ns.cmd=='mission': dump(p.command(ns.directive,mode=MissionMode(ns.mode) if ns.mode else None,risk=RiskClass(ns.risk) if ns.risk else None,crew_id=ns.crew,scope=ns.scope))
-    elif ns.cmd=='repair-write': dump(p.repair_write(ns.path,ns.content,risk=RiskClass(ns.risk) if ns.risk else None,crew_id=ns.crew))
-    elif ns.cmd=='graph-mission':
-        plan=json.loads(Path(ns.plan).read_text())
-        dump(p.command_graph(ns.directive,plan=plan,risk=RiskClass(ns.risk) if ns.risk else None,allow_repair=ns.allow_repair,plan_source=ns.plan_source))
+    try:
+        if ns.cmd=='init': init_workspace(ns.workspace,ns.config_dir,ns.non_interactive,ns.json_output); return
+        if ns.cmd=='workspace': show_workspace(ns.config_dir,ns.json_output); return
+        if ns.cmd=='health': health(ns.json_output); return
+        if ns.cmd=='reconstitution-plan': reconstitution_plan(ns.json_output,ns.fresh_host,ns.source_changed); return
+        if ns.cmd=='snapshot':
+            pm=PersistenceManager(vessel_root()); dump(pm.create_snapshot(label=ns.label,output=Path(ns.out) if ns.out else None).to_dict()); return
+        if ns.cmd=='verify-snapshot':
+            pm=PersistenceManager(vessel_root()); dump(pm.verify_snapshot(Path(ns.path)).to_dict()); return
+        if ns.cmd=='restore-snapshot':
+            pm=PersistenceManager(vessel_root()); dump(pm.restore_snapshot(Path(ns.path),confirm=ns.confirm)); return
+        p=pilot()
+        if ns.cmd in (None,'bridge'): bridge(p); return
+        if ns.cmd=='status': status(p); return
+        if ns.cmd=='roster':
+            states={x['crew_id']:x for x in p.store.crew_states()}
+            for d in p.roster.all(): print(f"{d.crew_id:30} {d.division:14} {states[d.crew_id]['status']:8} tours={states[d.crew_id]['tours']} caps={','.join(sorted(d.capabilities))}")
+        elif ns.cmd=='missions': dump(p.store.recent_missions())
+        elif ns.cmd=='show': dump(p.store.mission(ns.mission_id))
+        elif ns.cmd=='mission': dump(p.command(ns.directive,mode=MissionMode(ns.mode) if ns.mode else None,risk=RiskClass(ns.risk) if ns.risk else None,crew_id=ns.crew,scope=ns.scope))
+        elif ns.cmd=='repair-write': dump(p.repair_write(ns.path,ns.content,risk=RiskClass(ns.risk) if ns.risk else None,crew_id=ns.crew))
+        elif ns.cmd=='graph-mission':
+            plan=json.loads(Path(ns.plan).read_text())
+            dump(p.command_graph(ns.directive,plan=plan,risk=RiskClass(ns.risk) if ns.risk else None,allow_repair=ns.allow_repair,plan_source=ns.plan_source))
+    except InstallationError as exc:
+        ap.error(str(exc))
 
 if __name__=='__main__': main()

--- a/src/grox/cli.py
+++ b/src/grox/cli.py
@@ -15,7 +15,14 @@ from .reconstitution import ReconstitutionPlanner
 from .vessel import resolve_vessel_root
 
 
+# Compatibility/test override only. Normal installed operation leaves this null
+# so operational root discovery remains lazy and fail-closed.
+ROOT: Path | None = None
+
+
 def vessel_root():
+    if ROOT is not None:
+        return Path(ROOT).expanduser().resolve()
     return resolve_vessel_root(module_file=__file__)
 
 

--- a/src/grox/installation.py
+++ b/src/grox/installation.py
@@ -302,17 +302,15 @@ def commission_workspace(
     if marker_exists:
         _validate_workspace_marker(marker, target)
 
+    if target.exists():
+        for name in WORKSPACE_DIRECTORIES:
+            child = target / name
+            if child.exists() and not child.is_dir():
+                raise InstallationError(
+                    f"GroX workspace layout collision: expected directory at {child}"
+                )
+
     target.mkdir(parents=True, exist_ok=True)
-    created: list[str] = []
-    for name in WORKSPACE_DIRECTORIES:
-        child = target / name
-        if child.exists() and not child.is_dir():
-            raise InstallationError(
-                f"GroX workspace layout collision: expected directory at {child}"
-            )
-        if not child.exists():
-            child.mkdir(parents=False)
-            created.append(name)
 
     if not marker_exists:
         _atomic_write_json(
@@ -323,6 +321,17 @@ def commission_workspace(
                 "workspace": str(target),
             },
         )
+
+    created: list[str] = []
+    for name in WORKSPACE_DIRECTORIES:
+        child = target / name
+        if child.exists() and not child.is_dir():
+            raise InstallationError(
+                f"GroX workspace layout collision: expected directory at {child}"
+            )
+        if not child.exists():
+            child.mkdir(parents=False)
+            created.append(name)
 
     _atomic_write_json(
         binding,

--- a/src/grox/installation.py
+++ b/src/grox/installation.py
@@ -1,0 +1,342 @@
+from __future__ import annotations
+
+import json
+import os
+import platform
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping
+
+
+CONFIG_SCHEMA_VERSION = 1
+WORKSPACE_SCHEMA_VERSION = 1
+WORKSPACE_KIND = "grox-vessel-workspace"
+BINDING_KIND = "grox-workspace-binding"
+WORKSPACE_MARKER = Path(".grox/workspace.json")
+WORKSPACE_DIRECTORIES = (
+    "state",
+    "memory",
+    "models",
+    "missions",
+    "evidence",
+    "workspace",
+    "snapshots",
+    "logs",
+    "exports",
+)
+
+
+class InstallationError(RuntimeError):
+    """Raised when installed-host workspace state is unsafe or malformed."""
+
+
+@dataclass(frozen=True)
+class CommissioningResult:
+    status: str
+    workspace: Path
+    config_file: Path
+    marker_file: Path
+    created_directories: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "status": self.status,
+            "workspace": str(self.workspace),
+            "config_file": str(self.config_file),
+            "marker_file": str(self.marker_file),
+            "created_directories": list(self.created_directories),
+            "schema_version": WORKSPACE_SCHEMA_VERSION,
+        }
+
+
+def _home_path(home: Path | str | None = None) -> Path:
+    if home is None:
+        return Path.home().expanduser().resolve()
+    return Path(home).expanduser().resolve()
+
+
+def default_workspace(*, home: Path | str | None = None) -> Path:
+    """Return the cross-platform user-visible default GroX workspace."""
+
+    return (_home_path(home) / "GroX").resolve()
+
+
+def platform_config_dir(
+    *,
+    system: str | None = None,
+    environ: Mapping[str, str] | None = None,
+    home: Path | str | None = None,
+) -> Path:
+    """Return the per-user GroX host-configuration directory.
+
+    Linux follows XDG_CONFIG_HOME when explicitly set; otherwise it uses the
+    conventional ~/.config/grox location. macOS uses the user's Application
+    Support directory. Unsupported platforms fail closed rather than guessing.
+    """
+
+    os_name = (system or platform.system()).strip()
+    env = os.environ if environ is None else environ
+    user_home = _home_path(home)
+
+    if os_name == "Linux":
+        configured = str(env.get("XDG_CONFIG_HOME", "")).strip()
+        if configured:
+            base = Path(configured).expanduser()
+            if not base.is_absolute():
+                raise InstallationError(
+                    "XDG_CONFIG_HOME must be absolute for GroX host configuration"
+                )
+            return (base / "grox").resolve()
+        return (user_home / ".config" / "grox").resolve()
+
+    if os_name == "Darwin":
+        return (user_home / "Library" / "Application Support" / "GroX").resolve()
+
+    raise InstallationError(
+        f"GroX local commissioning is not yet supported on host platform: {os_name or '<unknown>'}"
+    )
+
+
+def workspace_binding_file(
+    *,
+    config_dir: Path | str | None = None,
+    system: str | None = None,
+    environ: Mapping[str, str] | None = None,
+    home: Path | str | None = None,
+) -> Path:
+    root = (
+        Path(config_dir).expanduser().resolve()
+        if config_dir is not None
+        else platform_config_dir(system=system, environ=environ, home=home)
+    )
+    return root / "workspace.json"
+
+
+def workspace_marker_file(workspace: Path | str) -> Path:
+    return Path(workspace).expanduser().resolve() / WORKSPACE_MARKER
+
+
+def _read_json_object(path: Path, *, label: str) -> dict[str, object]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        raise
+    except (OSError, json.JSONDecodeError) as exc:
+        raise InstallationError(f"Malformed {label}: {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise InstallationError(f"Malformed {label}: expected JSON object at {path}")
+    return payload
+
+
+def _atomic_write_json(path: Path, payload: Mapping[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    encoded = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=str(path.parent))
+    temp_path = Path(temp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_path, path)
+    except Exception:
+        try:
+            temp_path.unlink(missing_ok=True)
+        finally:
+            raise
+
+
+def _validate_workspace_marker(path: Path, workspace: Path) -> None:
+    payload = _read_json_object(path, label="GroX workspace marker")
+    if payload.get("kind") != WORKSPACE_KIND:
+        raise InstallationError(f"Invalid GroX workspace marker kind: {path}")
+    if payload.get("schema_version") != WORKSPACE_SCHEMA_VERSION:
+        raise InstallationError(f"Unsupported GroX workspace marker schema: {path}")
+    recorded = payload.get("workspace")
+    if not isinstance(recorded, str) or Path(recorded).expanduser().resolve() != workspace:
+        raise InstallationError(f"GroX workspace marker path mismatch: {path}")
+
+
+def _validate_binding_payload(payload: Mapping[str, object], path: Path) -> Path:
+    if payload.get("kind") != BINDING_KIND:
+        raise InstallationError(f"Invalid GroX workspace binding kind: {path}")
+    if payload.get("schema_version") != CONFIG_SCHEMA_VERSION:
+        raise InstallationError(f"Unsupported GroX workspace binding schema: {path}")
+    raw_workspace = payload.get("workspace")
+    if not isinstance(raw_workspace, str) or not raw_workspace.strip():
+        raise InstallationError(f"Malformed GroX workspace binding path: {path}")
+    workspace = Path(raw_workspace).expanduser()
+    if not workspace.is_absolute():
+        raise InstallationError(f"GroX workspace binding must be absolute: {path}")
+    return workspace.resolve()
+
+
+def load_workspace_binding(
+    *,
+    config_dir: Path | str | None = None,
+    system: str | None = None,
+    environ: Mapping[str, str] | None = None,
+    home: Path | str | None = None,
+    require_marker: bool = True,
+) -> Path | None:
+    """Return the configured workspace or None when no binding exists.
+
+    Existing malformed or stale bindings fail closed. A configured path is not
+    silently accepted as a GroX workspace merely because the directory exists.
+    """
+
+    binding = workspace_binding_file(
+        config_dir=config_dir,
+        system=system,
+        environ=environ,
+        home=home,
+    )
+    if not binding.exists():
+        return None
+    payload = _read_json_object(binding, label="GroX workspace binding")
+    workspace = _validate_binding_payload(payload, binding)
+    if require_marker:
+        marker = workspace_marker_file(workspace)
+        if not marker.is_file():
+            raise InstallationError(
+                f"Configured GroX workspace is missing its marker: {marker}"
+            )
+        _validate_workspace_marker(marker, workspace)
+    return workspace
+
+
+def workspace_status(
+    *,
+    config_dir: Path | str | None = None,
+    system: str | None = None,
+    environ: Mapping[str, str] | None = None,
+    home: Path | str | None = None,
+) -> dict[str, object]:
+    binding = workspace_binding_file(
+        config_dir=config_dir,
+        system=system,
+        environ=environ,
+        home=home,
+    )
+    configured = load_workspace_binding(
+        config_dir=config_dir,
+        system=system,
+        environ=environ,
+        home=home,
+        require_marker=True,
+    )
+    if configured is None:
+        target = default_workspace(home=home)
+        return {
+            "configured": False,
+            "commissioned": False,
+            "workspace": str(target),
+            "default_workspace": str(target),
+            "config_file": str(binding),
+            "marker_file": str(workspace_marker_file(target)),
+        }
+    return {
+        "configured": True,
+        "commissioned": True,
+        "workspace": str(configured),
+        "default_workspace": str(default_workspace(home=home)),
+        "config_file": str(binding),
+        "marker_file": str(workspace_marker_file(configured)),
+    }
+
+
+def commission_workspace(
+    workspace: Path | str | None = None,
+    *,
+    config_dir: Path | str | None = None,
+    system: str | None = None,
+    environ: Mapping[str, str] | None = None,
+    home: Path | str | None = None,
+) -> CommissioningResult:
+    """Create or re-open a bounded GroX workspace and persist its host binding.
+
+    This is an installed-host foundation only. It does not turn the workspace
+    into the canonical operational source root and does not activate Pilot or
+    model authority.
+    """
+
+    target = (
+        Path(workspace).expanduser().resolve()
+        if workspace is not None
+        else default_workspace(home=home)
+    )
+    binding = workspace_binding_file(
+        config_dir=config_dir,
+        system=system,
+        environ=environ,
+        home=home,
+    )
+    marker = workspace_marker_file(target)
+
+    existing_binding = load_workspace_binding(
+        config_dir=config_dir,
+        system=system,
+        environ=environ,
+        home=home,
+        require_marker=True,
+    )
+    if existing_binding is not None and existing_binding != target:
+        raise InstallationError(
+            "GroX is already bound to a different commissioned workspace: "
+            f"{existing_binding}. Refusing implicit rebind to {target}."
+        )
+
+    if target.exists() and not target.is_dir():
+        raise InstallationError(f"GroX workspace path is not a directory: {target}")
+
+    marker_exists = marker.is_file()
+    if target.exists() and not marker_exists:
+        entries = list(target.iterdir())
+        if entries:
+            raise InstallationError(
+                "Refusing to claim a non-empty directory without a GroX workspace marker: "
+                f"{target}"
+            )
+
+    if marker_exists:
+        _validate_workspace_marker(marker, target)
+
+    target.mkdir(parents=True, exist_ok=True)
+    created: list[str] = []
+    for name in WORKSPACE_DIRECTORIES:
+        child = target / name
+        if child.exists() and not child.is_dir():
+            raise InstallationError(
+                f"GroX workspace layout collision: expected directory at {child}"
+            )
+        if not child.exists():
+            child.mkdir(parents=False)
+            created.append(name)
+
+    if not marker_exists:
+        _atomic_write_json(
+            marker,
+            {
+                "kind": WORKSPACE_KIND,
+                "schema_version": WORKSPACE_SCHEMA_VERSION,
+                "workspace": str(target),
+            },
+        )
+
+    _atomic_write_json(
+        binding,
+        {
+            "kind": BINDING_KIND,
+            "schema_version": CONFIG_SCHEMA_VERSION,
+            "workspace": str(target),
+        },
+    )
+
+    return CommissioningResult(
+        status="existing" if marker_exists else "created",
+        workspace=target,
+        config_file=binding,
+        marker_file=marker,
+        created_directories=tuple(created),
+    )

--- a/tests/unit/test_installation.py
+++ b/tests/unit/test_installation.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+from grox.installation import (
+    InstallationError,
+    WORKSPACE_DIRECTORIES,
+    commission_workspace,
+    default_workspace,
+    load_workspace_binding,
+    platform_config_dir,
+    workspace_binding_file,
+    workspace_marker_file,
+    workspace_status,
+)
+
+
+class InstallationTests(unittest.TestCase):
+    def test_default_workspace_uses_user_home(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            home = Path(td)
+            self.assertEqual(default_workspace(home=home), home / "GroX")
+
+    def test_linux_config_uses_default_xdg_location(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            home = Path(td)
+            self.assertEqual(
+                platform_config_dir(system="Linux", environ={}, home=home),
+                home / ".config" / "grox",
+            )
+
+    def test_linux_config_honors_absolute_xdg_config_home(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            xdg = root / "xdg"
+            self.assertEqual(
+                platform_config_dir(
+                    system="Linux",
+                    environ={"XDG_CONFIG_HOME": str(xdg)},
+                    home=root / "home",
+                ),
+                xdg / "grox",
+            )
+
+    def test_linux_config_rejects_relative_xdg_config_home(self) -> None:
+        with self.assertRaisesRegex(InstallationError, "XDG_CONFIG_HOME must be absolute"):
+            platform_config_dir(
+                system="Linux",
+                environ={"XDG_CONFIG_HOME": "relative/config"},
+                home="/tmp/example-home",
+            )
+
+    def test_macos_config_uses_application_support(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            home = Path(td)
+            self.assertEqual(
+                platform_config_dir(system="Darwin", environ={}, home=home),
+                home / "Library" / "Application Support" / "GroX",
+            )
+
+    def test_unsupported_platform_fails_closed(self) -> None:
+        with self.assertRaisesRegex(InstallationError, "not yet supported"):
+            platform_config_dir(system="Windows", environ={}, home="/tmp/home")
+
+    def test_unconfigured_status_reports_default_without_creating_files(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            home = root / "home"
+            config = root / "config"
+            report = workspace_status(
+                config_dir=config,
+                system="Linux",
+                environ={},
+                home=home,
+            )
+            self.assertFalse(report["configured"])
+            self.assertFalse(report["commissioned"])
+            self.assertEqual(report["workspace"], str((home / "GroX").resolve()))
+            self.assertFalse(config.exists())
+            self.assertFalse((home / "GroX").exists())
+
+    def test_commission_creates_bounded_workspace_and_binding(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            workspace = root / "vessel"
+            config = root / "config"
+            result = commission_workspace(
+                workspace,
+                config_dir=config,
+                system="Linux",
+                environ={},
+                home=root / "home",
+            )
+            self.assertEqual(result.status, "created")
+            self.assertEqual(result.workspace, workspace.resolve())
+            self.assertEqual(set(result.created_directories), set(WORKSPACE_DIRECTORIES))
+            self.assertTrue(workspace_marker_file(workspace).is_file())
+            self.assertTrue(workspace_binding_file(config_dir=config).is_file())
+            for name in WORKSPACE_DIRECTORIES:
+                self.assertTrue((workspace / name).is_dir(), name)
+            self.assertEqual(
+                load_workspace_binding(config_dir=config), workspace.resolve()
+            )
+            report = workspace_status(config_dir=config, home=root / "home")
+            self.assertTrue(report["configured"])
+            self.assertTrue(report["commissioned"])
+            self.assertEqual(report["workspace"], str(workspace.resolve()))
+
+    def test_commission_is_idempotent_for_same_workspace(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            workspace = root / "vessel"
+            config = root / "config"
+            first = commission_workspace(workspace, config_dir=config)
+            second = commission_workspace(workspace, config_dir=config)
+            self.assertEqual(first.status, "created")
+            self.assertEqual(second.status, "existing")
+            self.assertEqual(second.created_directories, ())
+            self.assertEqual(load_workspace_binding(config_dir=config), workspace.resolve())
+
+    def test_nonempty_unrelated_directory_is_not_claimed(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            workspace = root / "occupied"
+            workspace.mkdir()
+            (workspace / "unrelated.txt").write_text("keep me", encoding="utf-8")
+            with self.assertRaisesRegex(InstallationError, "Refusing to claim"):
+                commission_workspace(workspace, config_dir=root / "config")
+            self.assertEqual((workspace / "unrelated.txt").read_text(), "keep me")
+            self.assertFalse(workspace_marker_file(workspace).exists())
+
+    def test_workspace_path_that_is_file_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            workspace = root / "not-a-directory"
+            workspace.write_text("occupied", encoding="utf-8")
+            with self.assertRaisesRegex(InstallationError, "not a directory"):
+                commission_workspace(workspace, config_dir=root / "config")
+
+    def test_layout_collision_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            workspace = root / "vessel"
+            config = root / "config"
+            commission_workspace(workspace, config_dir=config)
+            state_dir = workspace / "state"
+            state_dir.rmdir()
+            state_dir.write_text("collision", encoding="utf-8")
+            with self.assertRaisesRegex(InstallationError, "layout collision"):
+                commission_workspace(workspace, config_dir=config)
+
+    def test_malformed_binding_json_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            config = Path(td) / "config"
+            binding = workspace_binding_file(config_dir=config)
+            binding.parent.mkdir(parents=True)
+            binding.write_text("{not-json", encoding="utf-8")
+            with self.assertRaisesRegex(InstallationError, "Malformed GroX workspace binding"):
+                load_workspace_binding(config_dir=config)
+
+    def test_relative_binding_path_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            config = Path(td) / "config"
+            binding = workspace_binding_file(config_dir=config)
+            binding.parent.mkdir(parents=True)
+            binding.write_text(
+                json.dumps(
+                    {
+                        "kind": "grox-workspace-binding",
+                        "schema_version": 1,
+                        "workspace": "relative/workspace",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(InstallationError, "must be absolute"):
+                load_workspace_binding(config_dir=config, require_marker=False)
+
+    def test_missing_marker_on_configured_workspace_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            workspace = root / "vessel"
+            config = root / "config"
+            commission_workspace(workspace, config_dir=config)
+            workspace_marker_file(workspace).unlink()
+            with self.assertRaisesRegex(InstallationError, "missing its marker"):
+                load_workspace_binding(config_dir=config)
+
+    def test_wrong_marker_kind_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            workspace = root / "vessel"
+            config = root / "config"
+            commission_workspace(workspace, config_dir=config)
+            marker = workspace_marker_file(workspace)
+            payload = json.loads(marker.read_text(encoding="utf-8"))
+            payload["kind"] = "not-grox"
+            marker.write_text(json.dumps(payload), encoding="utf-8")
+            with self.assertRaisesRegex(InstallationError, "Invalid GroX workspace marker kind"):
+                load_workspace_binding(config_dir=config)
+
+    def test_marker_path_mismatch_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            workspace = root / "vessel"
+            config = root / "config"
+            commission_workspace(workspace, config_dir=config)
+            marker = workspace_marker_file(workspace)
+            payload = json.loads(marker.read_text(encoding="utf-8"))
+            payload["workspace"] = str(root / "other")
+            marker.write_text(json.dumps(payload), encoding="utf-8")
+            with self.assertRaisesRegex(InstallationError, "marker path mismatch"):
+                load_workspace_binding(config_dir=config)
+
+    def test_implicit_rebind_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            config = root / "config"
+            first = root / "first"
+            second = root / "second"
+            commission_workspace(first, config_dir=config)
+            with self.assertRaisesRegex(InstallationError, "already bound"):
+                commission_workspace(second, config_dir=config)
+            self.assertFalse(second.exists())
+            self.assertEqual(load_workspace_binding(config_dir=config), first.resolve())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_installation.py
+++ b/tests/unit/test_installation.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+from contextlib import redirect_stdout
+import io
 import json
 from pathlib import Path
 import tempfile
 import unittest
+from unittest.mock import patch
 
+from grox import cli
 from grox.installation import (
     InstallationError,
     WORKSPACE_DIRECTORIES,
@@ -121,6 +125,21 @@ class InstallationTests(unittest.TestCase):
             self.assertEqual(second.created_directories, ())
             self.assertEqual(load_workspace_binding(config_dir=config), workspace.resolve())
 
+    def test_marked_partial_workspace_can_be_completed_on_retry(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            workspace = root / "vessel"
+            config = root / "config"
+            commission_workspace(workspace, config_dir=config)
+            workspace_binding_file(config_dir=config).unlink()
+            missing = workspace / "models"
+            missing.rmdir()
+            retried = commission_workspace(workspace, config_dir=config)
+            self.assertEqual(retried.status, "existing")
+            self.assertEqual(retried.created_directories, ("models",))
+            self.assertTrue(missing.is_dir())
+            self.assertEqual(load_workspace_binding(config_dir=config), workspace.resolve())
+
     def test_nonempty_unrelated_directory_is_not_claimed(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
@@ -226,6 +245,42 @@ class InstallationTests(unittest.TestCase):
                 commission_workspace(second, config_dir=config)
             self.assertFalse(second.exists())
             self.assertEqual(load_workspace_binding(config_dir=config), first.resolve())
+
+    def test_cli_init_and_workspace_do_not_require_operational_vessel_root(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            workspace = root / "vessel"
+            config = root / "config"
+            init_out = io.StringIO()
+            with patch(
+                "grox.cli.resolve_vessel_root",
+                side_effect=AssertionError("operational Vessel root must not resolve"),
+            ), redirect_stdout(init_out):
+                cli.main(
+                    [
+                        "init",
+                        "--workspace",
+                        str(workspace),
+                        "--config-dir",
+                        str(config),
+                        "--non-interactive",
+                        "--json",
+                    ]
+                )
+            initialized = json.loads(init_out.getvalue())
+            self.assertEqual(initialized["status"], "created")
+            self.assertEqual(initialized["workspace"], str(workspace.resolve()))
+
+            status_out = io.StringIO()
+            with patch(
+                "grox.cli.resolve_vessel_root",
+                side_effect=AssertionError("operational Vessel root must not resolve"),
+            ), redirect_stdout(status_out):
+                cli.main(["workspace", "--config-dir", str(config), "--json"])
+            reported = json.loads(status_out.getvalue())
+            self.assertTrue(reported["configured"])
+            self.assertTrue(reported["commissioned"])
+            self.assertEqual(reported["workspace"], str(workspace.resolve()))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Scope

Implements issue #90 as the first bounded NCI-1 runtime slice from canonical `main@94db7b727bf0ea8b6cfd60dc408dee1e7c051131`.

Changed surfaces:

- `src/grox/installation.py`
- `src/grox/cli.py`
- `tests/unit/test_installation.py`
- `.github/workflows/ci.yml`

## Implemented

- cross-platform default workspace foundation: `~/GroX`;
- Linux XDG-style and macOS Application Support host-config resolution;
- versioned workspace marker and host binding;
- safe bounded workspace layout with collision refusal;
- atomic JSON marker/binding writes;
- idempotent commissioning and retry support for a marked partial workspace;
- implicit workspace rebind refusal;
- lazy operational Vessel-root resolution in the CLI;
- installed-host `grox init` and `grox workspace` commands that do not require resolving the operational source root;
- wheel-bootstrap proof that an installed non-editable wheel can initialize and inspect a workspace from `/tmp` outside checkout;
- preservation of the existing fail-closed boundary: operational `grox status` outside a valid Vessel source root still fails, while explicit `GROX_VESSEL_ROOT` binding still works.

## Claim boundary

This is an installed-host workspace/config **foundation**, not a standalone installed GroX Vessel.

It does not yet provide:

- bare `grox` automatic first-run commissioning outside checkout;
- packaged immutable Vessel runtime assets independent of a source root;
- native language-model provisioning;
- desktop launcher creation;
- a one-command public installer;
- offline GorXu qualification.

No Crew, Mission Order/Tool Gateway, authority, package/release, Apex-stage, or A8 change.

Closes #90 only after exact-head CI, review, canonical merge, and exact-source verification.