### PR TITLE
NCI-1B: separate runtime, state, and work roots

### DIFF
--- a/src/grox/pilot.py
+++ b/src/grox/pilot.py
@@ -8,7 +8,8 @@ from .contracts import MissionOrder, MissionMode, RiskClass, Evidence, TourResul
 from .state import StateStore
 from .durable_state import DurableState
 from .crew.roster import CrewRoster
-from .tools.gateway import ToolGateway
+from .runtime_layout import VesselLayout
+from .tools.layout_gateway import LayoutToolGateway
 from .runtime.executor import CrewExecutor
 from .mission_control.core import MissionControl
 from .verification.core import IndependentVerifier
@@ -25,16 +26,20 @@ _RISK_RANK = {RiskClass.low:0, RiskClass.medium:1, RiskClass.high:2, RiskClass.c
 class PilotGorXu:
     """GroX's sole operational orchestrator."""
     def __init__(
-        self, vessel_root:Path, *, reasoner:Any=_AUTO, gateway_policy=None,
+        self, vessel_root:Path|VesselLayout, *, reasoner:Any=_AUTO, gateway_policy=None,
         extra_allowed_origins=(), secret_broker=None, mcp_registry=None,
     ):
-        self.root=vessel_root.resolve()
-        self.store=StateStore(self.root/'configs/state/grox.sqlite3')
+        layout=vessel_root if isinstance(vessel_root,VesselLayout) else VesselLayout.legacy(vessel_root)
+        self.layout=layout
+        self.root=layout.work_root
+        self.asset_root=layout.asset_root
+        self.state_root=layout.state_root
+        self.store=StateStore(layout.state_path('grox.sqlite3'))
         self.durable=DurableState(self.store)
-        self.roster=CrewRoster(self.root/'configs/crew/dossiers',self.store)
+        self.roster=CrewRoster(layout.asset_path('configs/crew/dossiers'),self.store)
         self.mission_control=MissionControl()
-        self.gateway=ToolGateway(
-            self.root, policy=gateway_policy, extra_allowed_origins=extra_allowed_origins,
+        self.gateway=LayoutToolGateway(
+            layout, policy=gateway_policy, extra_allowed_origins=extra_allowed_origins,
             secret_broker=secret_broker, mcp_registry=mcp_registry,
         )
         self.executor=CrewExecutor(self.gateway,self.durable)

--- a/src/grox/runtime_layout.py
+++ b/src/grox/runtime_layout.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+class RuntimeLayoutError(ValueError):
+    """Raised when GroX runtime/state/work roots are ambiguous or unsafe."""
+
+
+def _resolved(path: Path | str) -> Path:
+    return Path(path).expanduser().resolve()
+
+
+def _overlap(left: Path, right: Path) -> bool:
+    return (
+        left == right
+        or left.is_relative_to(right)
+        or right.is_relative_to(left)
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class VesselLayout:
+    """Filesystem role contract beneath GorXu.
+
+    `legacy_single_root=True` preserves the source-checkout layout exactly:
+    runtime assets, private state, and Commander work all share the historical
+    Vessel root, with private state below `configs/state`.
+
+    A separated layout requires non-overlapping runtime, state, and work roots.
+    That prevents ordinary Tool Gateway filesystem paths from reaching private
+    state or immutable runtime assets through a relative path.
+    """
+
+    asset_root: Path
+    state_root: Path
+    work_root: Path
+    legacy_single_root: bool = False
+
+    def __post_init__(self) -> None:
+        assets = _resolved(self.asset_root)
+        state = _resolved(self.state_root)
+        work = _resolved(self.work_root)
+        object.__setattr__(self, "asset_root", assets)
+        object.__setattr__(self, "state_root", state)
+        object.__setattr__(self, "work_root", work)
+
+        if self.legacy_single_root:
+            if not (assets == state == work):
+                raise RuntimeLayoutError(
+                    "legacy GroX layout requires asset, state, and work roots to be identical"
+                )
+            return
+
+        pairs = (
+            ("runtime assets", assets, "private state", state),
+            ("runtime assets", assets, "Commander work", work),
+            ("private state", state, "Commander work", work),
+        )
+        for left_name, left, right_name, right in pairs:
+            if _overlap(left, right):
+                raise RuntimeLayoutError(
+                    f"separated GroX roots must not overlap: {left_name}={left} ; "
+                    f"{right_name}={right}"
+                )
+
+    @classmethod
+    def legacy(cls, vessel_root: Path | str) -> "VesselLayout":
+        root = _resolved(vessel_root)
+        return cls(root, root, root, legacy_single_root=True)
+
+    @classmethod
+    def separated(
+        cls,
+        *,
+        asset_root: Path | str,
+        state_root: Path | str,
+        work_root: Path | str,
+    ) -> "VesselLayout":
+        return cls(
+            _resolved(asset_root),
+            _resolved(state_root),
+            _resolved(work_root),
+            legacy_single_root=False,
+        )
+
+    @property
+    def state_storage_root(self) -> Path:
+        if self.legacy_single_root:
+            return self.state_root / "configs" / "state"
+        return self.state_root
+
+    def asset_path(self, relative: str | Path) -> Path:
+        return (self.asset_root / relative).resolve()
+
+    def state_path(self, relative: str | Path) -> Path:
+        return (self.state_storage_root / relative).resolve()
+
+    def work_path(self, relative: str | Path) -> Path:
+        return (self.work_root / relative).resolve()
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "asset_root": str(self.asset_root),
+            "state_root": str(self.state_root),
+            "state_storage_root": str(self.state_storage_root),
+            "work_root": str(self.work_root),
+            "legacy_single_root": self.legacy_single_root,
+        }

--- a/src/grox/tools/layout_gateway.py
+++ b/src/grox/tools/layout_gateway.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from ..runtime_layout import VesselLayout
+from .browser import BrowserRuntime
+from .gateway import ToolDenied, ToolGateway
+from .policy import GatewayPolicy
+from .secrets import SecretDenied
+from .workspace import IsolatedWorkspace, WorkspaceUnavailable
+
+
+class LayoutToolGateway(ToolGateway):
+    """Tool Gateway bound to explicit GroX filesystem roles.
+
+    Ordinary filesystem authority remains rooted at the Commander work root.
+    Host policy and other immutable runtime assets are read from asset_root.
+    Browser evidence and isolated-workspace scratch are kept under private
+    state_root. Mission Order action and scope semantics remain those of the
+    base Tool Gateway.
+    """
+
+    def __init__(
+        self,
+        layout: VesselLayout,
+        *,
+        policy: GatewayPolicy | None = None,
+        extra_allowed_origins=(),
+        secret_broker=None,
+        mcp_registry=None,
+    ):
+        effective_policy = policy or GatewayPolicy.from_file(
+            layout.asset_path("configs/tool-policy.json"),
+            extra_allowed_origins=extra_allowed_origins,
+        )
+        super().__init__(
+            layout.work_root,
+            policy=effective_policy,
+            secret_broker=secret_broker,
+            mcp_registry=mcp_registry,
+        )
+        self.layout = layout
+        self.asset_root = layout.asset_root
+        self.state_root = layout.state_root
+        self.state_storage_root = layout.state_storage_root
+        # BrowserRuntime uses its root only for mutable capture evidence. Its
+        # executable/module discovery remains independent of this path.
+        self._browser = BrowserRuntime(self.state_storage_root, self.policy)
+
+    def workspace_shell(self, order, script: str, *, secret_env: dict[str, str] | None = None) -> dict:
+        self._allowed(order, "workspace_exec")
+        if not self.policy.workspace_enabled:
+            raise ToolDenied("isolated workspace disabled by host policy")
+        secret_values: dict[str, str] = {}
+        aliases: list[str] = []
+        if secret_env:
+            self._allowed(order, "secret_use")
+            try:
+                secret_values, aliases = self.secret_broker.materialize_env(order, secret_env)
+            except SecretDenied as exc:
+                raise ToolDenied(str(exc)) from exc
+        if self._workspace is None:
+            try:
+                self._workspace = IsolatedWorkspace(
+                    self.state_storage_root / "workspaces",
+                    timeout_seconds=self.policy.workspace_timeout_seconds,
+                    memory_bytes=self.policy.workspace_memory_bytes,
+                    file_bytes=self.policy.workspace_file_bytes,
+                    docker_image=self.policy.workspace_docker_image,
+                )
+            except WorkspaceUnavailable as exc:
+                raise ToolDenied(str(exc)) from exc
+        result = self._workspace.run(order.mission_id, order.order_id, script, env=secret_values)
+        result["stdout"] = self.secret_broker.redact(result["stdout"], secret_values)
+        result["stderr"] = self.secret_broker.redact(result["stderr"], secret_values)
+        result["secret_aliases"] = aliases
+        return result

--- a/tests/unit/test_runtime_layout.py
+++ b/tests/unit/test_runtime_layout.py
@@ -62,7 +62,7 @@ class VesselLayoutTests(unittest.TestCase):
     def test_legacy_layout_rejects_nonidentical_roles(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
-            with self.assertRaisesRegex(RuntimeLayoutError, "must be identical"):
+            with self.assertRaisesRegex(RuntimeLayoutError, "to be identical"):
                 VesselLayout(
                     root / "assets",
                     root / "state",

--- a/tests/unit/test_runtime_layout.py
+++ b/tests/unit/test_runtime_layout.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+import tempfile
+import unittest
+
+from grox.contracts import MissionMode, MissionOrder, RiskClass
+from grox.pilot import PilotGorXu
+from grox.runtime_layout import RuntimeLayoutError, VesselLayout
+from grox.tools.gateway import ToolDenied
+from grox.tools.policy import GatewayPolicy
+
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+class VesselLayoutTests(unittest.TestCase):
+    def test_legacy_layout_preserves_historical_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td).resolve()
+            layout = VesselLayout.legacy(root)
+            self.assertTrue(layout.legacy_single_root)
+            self.assertEqual(layout.asset_root, root)
+            self.assertEqual(layout.state_root, root)
+            self.assertEqual(layout.work_root, root)
+            self.assertEqual(
+                layout.state_path("grox.sqlite3"),
+                root / "configs" / "state" / "grox.sqlite3",
+            )
+            self.assertEqual(
+                layout.asset_path("configs/tool-policy.json"),
+                root / "configs" / "tool-policy.json",
+            )
+
+    def test_separated_layout_uses_direct_private_state_root(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            layout = VesselLayout.separated(
+                asset_root=root / "assets",
+                state_root=root / "state",
+                work_root=root / "work",
+            )
+            self.assertFalse(layout.legacy_single_root)
+            self.assertEqual(layout.state_path("grox.sqlite3"), (root / "state" / "grox.sqlite3").resolve())
+            self.assertEqual(layout.work_path("notes.txt"), (root / "work" / "notes.txt").resolve())
+
+    def test_separated_layout_rejects_overlapping_roots(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            with self.assertRaisesRegex(RuntimeLayoutError, "must not overlap"):
+                VesselLayout.separated(
+                    asset_root=root / "assets",
+                    state_root=root / "work" / "state",
+                    work_root=root / "work",
+                )
+
+    def test_legacy_layout_rejects_nonidentical_roles(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            with self.assertRaisesRegex(RuntimeLayoutError, "must be identical"):
+                VesselLayout(
+                    root / "assets",
+                    root / "state",
+                    root / "work",
+                    legacy_single_root=True,
+                )
+
+
+class SeparatedPilotTests(unittest.TestCase):
+    def test_pilot_separates_runtime_state_and_commander_work(self) -> None:
+        policy_path = REPO / "configs" / "tool-policy.json"
+        policy_before = sha256(policy_path)
+
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            state = root / "state"
+            work = root / "work"
+            (work / "tests").mkdir(parents=True)
+            (work / "notes.txt").write_text("Commander workspace evidence\n", encoding="utf-8")
+            (work / "tests" / "test_smoke.py").write_text(
+                "import unittest\n\n"
+                "class Smoke(unittest.TestCase):\n"
+                "    def test_workspace(self):\n"
+                "        self.assertTrue(True)\n",
+                encoding="utf-8",
+            )
+
+            layout = VesselLayout.separated(
+                asset_root=REPO,
+                state_root=state,
+                work_root=work,
+            )
+            pilot = PilotGorXu(layout, reasoner=None)
+            try:
+                self.assertEqual(pilot.layout, layout)
+                self.assertEqual(pilot.root, work.resolve())
+                self.assertEqual(pilot.asset_root, REPO.resolve())
+                self.assertEqual(pilot.state_root, state.resolve())
+                self.assertEqual(pilot.gateway.root, work.resolve())
+                self.assertEqual(pilot.gateway.asset_root, REPO.resolve())
+                self.assertEqual(pilot.gateway.state_storage_root, state.resolve())
+                self.assertEqual(pilot.gateway._browser.root, state.resolve())
+                self.assertEqual(len(pilot.roster.all()), 82)
+                self.assertTrue((state / "grox.sqlite3").is_file())
+                self.assertFalse((work / "configs" / "state" / "grox.sqlite3").exists())
+                self.assertEqual(
+                    pilot.gateway.policy,
+                    GatewayPolicy.from_file(policy_path),
+                )
+
+                result = pilot.command(
+                    "Inspect Commander workspace",
+                    mode=MissionMode.inspect,
+                    risk=RiskClass.low,
+                    scope=".",
+                )
+                self.assertEqual(result["status"], "completed")
+                self.assertEqual(result["outcome"]["effect"], "inspection")
+                self.assertFalse(result["outcome"]["mutation"])
+                self.assertTrue((state / "grox.sqlite3").is_file())
+                self.assertEqual((work / "notes.txt").read_text(encoding="utf-8"), "Commander workspace evidence\n")
+                self.assertEqual(sha256(policy_path), policy_before)
+
+                order = MissionOrder.new(
+                    "MSN-layout-boundary",
+                    "Inspect bounded Commander work",
+                    "Read only inside Commander work root",
+                    MissionMode.inspect,
+                    "repository-inspector",
+                    allowed_actions=["fs_read"],
+                    forbidden_actions=["fs_write"],
+                    scope=["."],
+                    risk_class=RiskClass.low,
+                )
+                with self.assertRaisesRegex(ToolDenied, "escapes Vessel root"):
+                    pilot.gateway.read_text(order, "../state/grox.sqlite3")
+                with self.assertRaisesRegex(ToolDenied, "escapes Vessel root"):
+                    pilot.gateway.read_text(order, str(policy_path.resolve()))
+            finally:
+                pilot.store.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Scope

Implements issue #92 from canonical `main@2b4e1c8f3fff8081a30dab4702738cf8b5c01480`.

Changed surfaces:

- `src/grox/runtime_layout.py`
- `src/grox/tools/layout_gateway.py`
- `src/grox/pilot.py`
- `tests/unit/test_runtime_layout.py`

## Implemented

- explicit `VesselLayout` with runtime/assets, private state, and Commander work roots;
- strict non-overlap requirement for separated layouts;
- exact legacy one-root compatibility, including historical `configs/state/grox.sqlite3` placement;
- `PilotGorXu(vessel_root)` compatibility plus direct `PilotGorXu(VesselLayout)` support;
- Standing Crew/craft loading from runtime assets;
- StateStore placement under private state in separated mode;
- Tool Gateway filesystem authority rooted only in Commander work;
- Tool Gateway host policy sourced from runtime assets;
- Browser evidence and isolated-workspace scratch routed to private state;
- regression proof that a separated Pilot loads 82 Crew, performs a bounded Inspect Mission against Commander work, keeps runtime assets unchanged, and rejects filesystem escape attempts into private state/runtime assets.

## Verification

- authoritative exact-head CI: run 270 / `32356241254` on `726b29e86e41b56d1e527960960f464a13ede6de` — PASS across all five jobs;
- CI-tested synthetic merge tree: `fa4255792801a2b45a2b1daad2ecee334a55484d`;
- canonical merge: `55c98b13a169476cfedad89c1db2c2c36e9536fd`;
- canonical merge tree: `fa4255792801a2b45a2b1daad2ecee334a55484d` — exact tree match.

## Claim boundary

This is NCI-1 filesystem-role separation only. It does not yet package canonical runtime assets into the wheel, start an installed standalone Pilot, provision a native language model, create desktop launchers, advertise a one-command installer, or qualify offline GorXu.

No Crew, Mission authority, Tool Gateway grant semantics, package/release, Apex-stage, or A8 change.