### PR TITLE
NCI-1C: package runtime assets for standalone installed GorXu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,20 @@ jobs:
           python -m venv /tmp/grox-wheel-env
           /tmp/grox-wheel-env/bin/python -m pip install /tmp/grox-wheel/grox_vessel-*.whl
           /tmp/grox-wheel-env/bin/python -m pip check
+      - name: Packaged runtime assets are complete
+        run: |
+          (cd /tmp && /tmp/grox-wheel-env/bin/python - <<'PY'
+          from pathlib import Path
+          from grox.runtime_assets import packaged_asset_root
+          root = packaged_asset_root()
+          dossiers = list((root / 'configs/crew/dossiers').glob('*.json'))
+          craft = list((root / 'configs/crew/specialists').glob('*.md'))
+          assert len(dossiers) == 82, len(dossiers)
+          assert len(craft) == 82, len(craft)
+          Path('/tmp/grox-asset-root.txt').write_text(str(root))
+          print(root)
+          PY
+          )
       - name: Installed CLI binds to current Vessel checkout
         run: |
           /tmp/grox-wheel-env/bin/python -m grox.cli status | tee /tmp/grox-wheel-status.txt
@@ -160,18 +174,86 @@ jobs:
           assert reported['commissioned'] is True, reported
           assert reported['workspace'] == '/tmp/grox-user-vessel', reported
           PY
-      - name: Unbound operational CLI still fails closed
+      - name: Uncommissioned installed operation fails closed
         run: |
           set +e
-          output=$(cd /tmp && /tmp/grox-wheel-env/bin/python -m grox.cli status 2>&1)
+          output=$(cd /tmp && XDG_CONFIG_HOME=/tmp/grox-uncommissioned-config /tmp/grox-wheel-env/bin/python -m grox.cli status 2>&1)
           rc=$?
           set -e
           printf '%s\n' "$output"
           test "$rc" -ne 0
-          grep -q 'No GroX Vessel root found' <<<"$output"
-          grep -q 'Refusing to start an empty Vessel' <<<"$output"
+          grep -q 'No commissioned GroX workspace found' <<<"$output"
+          grep -q 'grox init' <<<"$output"
       - name: Explicit Vessel binding works outside checkout
         run: |
           (cd /tmp && GROX_VESSEL_ROOT="$GITHUB_WORKSPACE" /tmp/grox-wheel-env/bin/python -m grox.cli status) | tee /tmp/grox-bound-status.txt
           grep -q 'Standing Crew: 82' /tmp/grox-bound-status.txt
           grep -q "Vessel root: $GITHUB_WORKSPACE" /tmp/grox-bound-status.txt
+      - name: Standalone installed GorXu commissions and starts
+        run: |
+          rm -rf /tmp/grox-installed-xdg /tmp/grox-installed-vessel
+          (cd /tmp && XDG_CONFIG_HOME=/tmp/grox-installed-xdg /tmp/grox-wheel-env/bin/python -m grox.cli init \
+            --workspace /tmp/grox-installed-vessel \
+            --non-interactive \
+            --json) | tee /tmp/grox-installed-init.json
+          mkdir -p /tmp/grox-installed-vessel/workspace/tests
+          cat > /tmp/grox-installed-vessel/workspace/tests/test_smoke.py <<'PY'
+          import unittest
+
+          class InstalledWorkspaceSmoke(unittest.TestCase):
+              def test_commander_workspace(self):
+                  self.assertTrue(True)
+          PY
+          echo 'Commander workspace file' > /tmp/grox-installed-vessel/workspace/README.txt
+          (cd /tmp && XDG_CONFIG_HOME=/tmp/grox-installed-xdg /tmp/grox-wheel-env/bin/python -m grox.cli status) | tee /tmp/grox-installed-status.txt
+          grep -q 'Command spine: Commander -> Pilot GorXu -> Divisions -> Standing Crew' /tmp/grox-installed-status.txt
+          grep -q 'Standing Crew: 82' /tmp/grox-installed-status.txt
+          grep -q 'Private state: /tmp/grox-installed-vessel/state' /tmp/grox-installed-status.txt
+          grep -q 'Commander workspace: /tmp/grox-installed-vessel/workspace' /tmp/grox-installed-status.txt
+          test -f /tmp/grox-installed-vessel/state/grox.sqlite3
+          asset_root=$(cat /tmp/grox-asset-root.txt)
+          test ! -e "$asset_root/configs/state/grox.sqlite3"
+      - name: Standalone installed GorXu orchestrates bounded Crew work
+        run: |
+          (cd /tmp && XDG_CONFIG_HOME=/tmp/grox-installed-xdg /tmp/grox-wheel-env/bin/python -m grox.cli mission \
+            'inspect the commissioned Commander workspace' \
+            --mode inspect \
+            --risk medium \
+            --crew code-reviewer \
+            --scope .) | tee /tmp/grox-installed-mission.json
+          /tmp/grox-wheel-env/bin/python - <<'PY'
+          import json
+          from pathlib import Path
+          result = json.loads(Path('/tmp/grox-installed-mission.json').read_text())
+          assert result['crew'] == 'code-reviewer', result
+          assert result['mode'] == 'inspect', result
+          assert result['risk'] == 'medium', result
+          assert result['execution_status'] == 'completed', result
+          assert result['verification'] is not None, result
+          assert result['verification']['ok'] is True, result
+          assert result['verification']['verifier'] != result['crew'], result
+          assert result['outcome']['mutation'] is False, result
+          Path('/tmp/grox-installed-mission-id.txt').write_text(result['mission_id'])
+          PY
+      - name: Installed Vessel reconstitutes the same private state
+        run: |
+          mission_id=$(cat /tmp/grox-installed-mission-id.txt)
+          (cd /tmp && XDG_CONFIG_HOME=/tmp/grox-installed-xdg /tmp/grox-wheel-env/bin/python -m grox.cli status) | tee /tmp/grox-installed-reopen.txt
+          grep -q 'Standing Crew: 82' /tmp/grox-installed-reopen.txt
+          grep -q "Last mission: $mission_id" /tmp/grox-installed-reopen.txt
+          test -f /tmp/grox-installed-vessel/state/grox.sqlite3
+      - name: Corrupt packaged runtime fails closed
+        run: |
+          asset_root=$(cat /tmp/grox-asset-root.txt)
+          policy="$asset_root/configs/tool-policy.json"
+          backup="$asset_root/configs/tool-policy.json.nci1c-backup"
+          mv "$policy" "$backup"
+          set +e
+          output=$(cd /tmp && XDG_CONFIG_HOME=/tmp/grox-installed-xdg /tmp/grox-wheel-env/bin/python -m grox.cli status 2>&1)
+          rc=$?
+          set -e
+          mv "$backup" "$policy"
+          printf '%s\n' "$output"
+          test "$rc" -ne 0
+          grep -q 'packaged runtime assets are incomplete' <<<"$output"
+          (cd /tmp && XDG_CONFIG_HOME=/tmp/grox-installed-xdg /tmp/grox-wheel-env/bin/python -m grox.cli status) >/dev/null

--- a/docs/verification/NCI_1C_INSTALLATION_EVIDENCE.md
+++ b/docs/verification/NCI_1C_INSTALLATION_EVIDENCE.md
@@ -1,0 +1,57 @@
+# NCI-1C Standalone Installed GorXu Evidence
+
+**Status:** IMPLEMENTED CANDIDATE — QUALIFICATION PENDING  
+**Issue:** #96  
+**Program:** Native Cognition Independence Program 001
+
+## Objective
+
+Prove that a non-editable installed GroX wheel can start the same canonical `PilotGorXu` outside a source checkout by using packaged immutable runtime assets and a commissioned NCI-1B separated Vessel layout.
+
+Canonical command relationship remains:
+
+> **Commander → Pilot GorXu → Divisions → Standing Crew**
+
+Runtime assets, package metadata, private state, Commander workspace, tools, models, and installers are infrastructure beneath this command hierarchy.
+
+## Candidate implementation
+
+The candidate:
+
+- packages the canonical repository `configs/` runtime inputs directly into the wheel data area rather than maintaining a second Crew/config tree;
+- validates packaged policy, company manifest, exactly 82 Standing Crew dossiers, exactly 82 matching craft cards, and dossier identity before installed Pilot startup;
+- preserves explicit/source-checkout operation as the developer and recovery path;
+- falls back outside a checkout to a commissioned workspace plus validated packaged runtime assets;
+- constructs the existing `VesselLayout.separated(...)` with immutable assets, private state, and Commander work roots;
+- instantiates the existing `PilotGorXu`; no installed-only orchestrator is introduced;
+- preserves Tool Gateway confinement to Commander work and private SQLite state outside package assets;
+- fails closed when no commissioned workspace exists or packaged runtime assets are incomplete/malformed.
+
+## Qualification gate
+
+Protected CI must prove from a non-editable wheel outside the repository:
+
+1. the packaged runtime bundle validates with exactly 82 dossiers and 82 matching craft cards;
+2. uncommissioned installed operation fails closed;
+3. explicit source binding still works for developer/recovery operation;
+4. a commissioned installed Vessel starts canonical Pilot GorXu with all 82 Standing Crew;
+5. runtime assets, private state, and Commander workspace remain separated;
+6. a bounded medium-risk Inspect Mission is issued by GorXu to `code-reviewer` and independently verified by a different eligible Crew member;
+7. the Mission produces no mutation;
+8. a fresh CLI process reopens the same private state and sees the same Mission;
+9. deliberate removal of a required packaged policy asset causes fail-closed startup and recovery succeeds after restoration;
+10. Python 3.11–3.14 regressions, Wheel bootstrap, Health, reconstitution, context experiments, mutation suites, provenance, and integrated Post-Apex qualification all remain green.
+
+## Claim boundary
+
+Until exact-head protected CI and canonical merge/source equivalence pass, NCI-1C remains an implementation candidate only.
+
+Even after NCI-1C qualification, it will not by itself establish:
+
+- a native general-purpose language model;
+- NCI-2 seed cognition;
+- offline GorXu cognition;
+- a desktop launcher;
+- a public one-command installer;
+- a new package/release version;
+- a new Apex stage or A8.

--- a/docs/verification/NCI_1C_INSTALLATION_EVIDENCE.md
+++ b/docs/verification/NCI_1C_INSTALLATION_EVIDENCE.md
@@ -42,6 +42,10 @@ Protected CI must prove from a non-editable wheel outside the repository:
 9. deliberate removal of a required packaged policy asset causes fail-closed startup and recovery succeeds after restoration;
 10. Python 3.11–3.14 regressions, Wheel bootstrap, Health, reconstitution, context experiments, mutation suites, provenance, and integrated Post-Apex qualification all remain green.
 
+## Evidence state
+
+This file intentionally contains no PASS result yet. Exact-head CI run identifiers, final head/tree digests, and canonical merge/source-equivalence evidence will be added only after those events actually occur.
+
 ## Claim boundary
 
 Until exact-head protected CI and canonical merge/source equivalence pass, NCI-1C remains an implementation candidate only.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,14 @@ package-dir = {"" = "src"}
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.setuptools.data-files]
+"share/grox/configs" = ["configs/tool-policy.json"]
+"share/grox/configs/crew" = ["configs/crew/company-manifest.json"]
+"share/grox/configs/crew/dossiers" = ["configs/crew/dossiers/*.json"]
+"share/grox/configs/crew/specialists" = ["configs/crew/specialists/*.md"]
+"share/grox/configs/persistence" = ["configs/persistence/*.json"]
+"share/grox/configs/reasoning" = ["configs/reasoning/*.md"]
+
 [tool.pytest.ini_options]
 pythonpath = ["src"]
 testpaths = ["tests"]

--- a/src/grox/cli.py
+++ b/src/grox/cli.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-import argparse, json
+import argparse, json, os
 from pathlib import Path
 from .pilot import PilotGorXu
 from .contracts import MissionMode, RiskClass
@@ -8,11 +8,13 @@ from .installation import (
     InstallationError,
     commission_workspace,
     default_workspace,
+    installed_vessel_layout,
     workspace_status,
 )
 from .persistence import PersistenceManager
 from .reconstitution import ReconstitutionPlanner
-from .vessel import resolve_vessel_root
+from .runtime_layout import VesselLayout
+from .vessel import VesselRootError, resolve_vessel_root
 
 
 # Compatibility/test override only. Normal installed operation leaves this null
@@ -26,7 +28,29 @@ def vessel_root():
     return resolve_vessel_root(module_file=__file__)
 
 
-def pilot(): return PilotGorXu(vessel_root())
+def operational_layout() -> VesselLayout:
+    """Resolve the one GorXu runtime layout for source or installed operation.
+
+    Explicit/source checkout binding remains the developer/recovery path. A
+    non-editable installed runtime outside a checkout falls back only to a
+    commissioned workspace plus the validated packaged runtime bundle.
+    """
+
+    if ROOT is not None:
+        return VesselLayout.legacy(vessel_root())
+
+    # An explicit source binding is authoritative. If it is invalid, preserve
+    # the fail-closed VesselRootError instead of silently switching modes.
+    if str(os.environ.get("GROX_VESSEL_ROOT", "")).strip():
+        return VesselLayout.legacy(vessel_root())
+
+    try:
+        return VesselLayout.legacy(vessel_root())
+    except VesselRootError:
+        return installed_vessel_layout()
+
+
+def pilot(): return PilotGorXu(operational_layout())
 
 def dump(x): print(json.dumps(x,indent=2,default=str))
 
@@ -34,7 +58,12 @@ def status(p):
     ms=p.store.recent_missions(5); states=p.store.crew_states()
     print("GroX Vessel: ONLINE")
     print("Command spine: Commander -> Pilot GorXu -> Divisions -> Standing Crew")
-    print(f"Vessel root: {p.root}")
+    if p.layout.legacy_single_root:
+        print(f"Vessel root: {p.root}")
+    else:
+        print(f"Runtime assets: {p.layout.asset_root}")
+        print(f"Private state: {p.layout.state_root}")
+        print(f"Commander workspace: {p.layout.work_root}")
     print(f"Standing Crew: {len(p.roster.all())} | Missions recorded: {len(p.store.recent_missions(1000))}")
     print(f"Cognitive Pilot: {p.cognitive_status}")
     active=[x for x in states if x['status']=='on_duty']; print(f"Crew on duty: {len(active)}")
@@ -82,7 +111,7 @@ def init_workspace(workspace=None,config_dir=None,non_interactive=False,json_out
         print(f"Created directories: {', '.join(result.created_directories)}")
     else:
         print("Created directories: none (existing commissioned foundation)")
-    print("Operational Pilot startup still requires a valid GroX Vessel source binding in NCI-1A.")
+    print("Installed GorXu can start when the GroX runtime bundle is present and validated.")
 
 def show_workspace(config_dir=None,json_output=False):
     report=workspace_status(config_dir=Path(config_dir).expanduser() if config_dir else None)

--- a/src/grox/installation.py
+++ b/src/grox/installation.py
@@ -8,6 +8,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Mapping
 
+from .runtime_assets import RuntimeAssetError, packaged_asset_root, validate_asset_root
+from .runtime_layout import RuntimeLayoutError, VesselLayout
+
 
 CONFIG_SCHEMA_VERSION = 1
 WORKSPACE_SCHEMA_VERSION = 1
@@ -349,3 +352,52 @@ def commission_workspace(
         marker_file=marker,
         created_directories=tuple(created),
     )
+
+
+def installed_vessel_layout(
+    *,
+    config_dir: Path | str | None = None,
+    system: str | None = None,
+    environ: Mapping[str, str] | None = None,
+    home: Path | str | None = None,
+    asset_root: Path | str | None = None,
+) -> VesselLayout:
+    """Resolve the commissioned installed Vessel into the NCI-1B layout.
+
+    The immutable runtime bundle is validated independently from the mutable
+    workspace. Private state and Commander work remain separate roots beneath
+    the same Pilot GorXu command plane.
+    """
+
+    workspace = load_workspace_binding(
+        config_dir=config_dir,
+        system=system,
+        environ=environ,
+        home=home,
+        require_marker=True,
+    )
+    if workspace is None:
+        raise InstallationError(
+            "No commissioned GroX workspace found. Run `grox init` before starting installed GorXu."
+        )
+
+    try:
+        assets = validate_asset_root(asset_root) if asset_root is not None else packaged_asset_root()
+    except RuntimeAssetError as exc:
+        raise InstallationError(str(exc)) from exc
+
+    state_root = workspace / "state"
+    work_root = workspace / "workspace"
+    if not state_root.is_dir() or not work_root.is_dir():
+        raise InstallationError(
+            "Commissioned GroX workspace is missing required state/workspace directories"
+        )
+
+    try:
+        return VesselLayout.separated(
+            asset_root=assets,
+            state_root=state_root,
+            work_root=work_root,
+        )
+    except RuntimeLayoutError as exc:
+        raise InstallationError(f"Unsafe installed GroX filesystem layout: {exc}") from exc

--- a/src/grox/runtime_assets.py
+++ b/src/grox/runtime_assets.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import json
+from importlib import metadata
+from pathlib import Path
+
+
+DISTRIBUTION_NAME = "grox-vessel"
+EXPECTED_STANDING_CREW = 82
+
+
+class RuntimeAssetError(RuntimeError):
+    """Raised when installed GroX runtime assets are missing or malformed."""
+
+
+def validate_asset_root(asset_root: Path | str) -> Path:
+    """Validate the immutable runtime bundle required to construct GorXu.
+
+    This check is deliberately structural and fail-closed. It verifies the
+    canonical policy/manifest files, the complete Standing Crew dossier set,
+    matching deep-craft cards, and parseability/identity of every dossier.
+    Runtime assets remain infrastructure beneath GorXu; validation does not
+    activate models, Crew, or authority.
+    """
+
+    root = Path(asset_root).expanduser().resolve()
+    policy = root / "configs" / "tool-policy.json"
+    manifest = root / "configs" / "crew" / "company-manifest.json"
+    dossiers_dir = root / "configs" / "crew" / "dossiers"
+    specialists_dir = root / "configs" / "crew" / "specialists"
+
+    required = (policy, manifest, dossiers_dir, specialists_dir)
+    missing = [str(path) for path in required if not path.exists()]
+    if missing:
+        raise RuntimeAssetError(
+            "GroX packaged runtime assets are incomplete; missing: " + ", ".join(missing)
+        )
+
+    try:
+        json.loads(policy.read_text(encoding="utf-8"))
+        json.loads(manifest.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeAssetError(f"GroX packaged runtime metadata is malformed: {exc}") from exc
+
+    dossiers = sorted(dossiers_dir.glob("*.json"))
+    specialists = sorted(specialists_dir.glob("*.md"))
+    if len(dossiers) != EXPECTED_STANDING_CREW:
+        raise RuntimeAssetError(
+            f"GroX packaged runtime must contain exactly {EXPECTED_STANDING_CREW} Standing Crew dossiers; "
+            f"found {len(dossiers)}"
+        )
+    if len(specialists) != EXPECTED_STANDING_CREW:
+        raise RuntimeAssetError(
+            f"GroX packaged runtime must contain exactly {EXPECTED_STANDING_CREW} Standing Crew craft cards; "
+            f"found {len(specialists)}"
+        )
+
+    dossier_ids = {path.stem for path in dossiers}
+    specialist_ids = {path.stem for path in specialists}
+    if dossier_ids != specialist_ids:
+        missing_craft = sorted(dossier_ids - specialist_ids)
+        orphan_craft = sorted(specialist_ids - dossier_ids)
+        raise RuntimeAssetError(
+            "GroX packaged Crew/craft identity mismatch: "
+            f"missing_craft={missing_craft}; orphan_craft={orphan_craft}"
+        )
+
+    for path in dossiers:
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise RuntimeAssetError(f"Malformed packaged Crew dossier: {path}: {exc}") from exc
+        if not isinstance(payload, dict):
+            raise RuntimeAssetError(f"Malformed packaged Crew dossier object: {path}")
+        crew_id = payload.get("crew_id")
+        if crew_id != path.stem:
+            raise RuntimeAssetError(
+                f"Packaged Crew dossier identity mismatch: {path.name}: crew_id={crew_id!r}"
+            )
+
+    return root
+
+
+def packaged_asset_root() -> Path:
+    """Locate and validate the runtime assets installed by the GroX wheel."""
+
+    try:
+        dist = metadata.distribution(DISTRIBUTION_NAME)
+    except metadata.PackageNotFoundError as exc:
+        raise RuntimeAssetError(
+            f"Installed GroX distribution is unavailable: {DISTRIBUTION_NAME}"
+        ) from exc
+
+    files = dist.files or ()
+    suffix = "share/grox/configs/tool-policy.json"
+    for item in files:
+        normalized = str(item).replace("\\", "/")
+        if not normalized.endswith(suffix):
+            continue
+        policy = Path(dist.locate_file(item)).resolve()
+        return validate_asset_root(policy.parent.parent)
+
+    raise RuntimeAssetError(
+        "Installed GroX distribution does not contain the packaged runtime asset bundle"
+    )

--- a/src/grox/runtime_assets.py
+++ b/src/grox/runtime_assets.py
@@ -101,5 +101,6 @@ def packaged_asset_root() -> Path:
         return validate_asset_root(policy.parent.parent)
 
     raise RuntimeAssetError(
-        "Installed GroX distribution does not contain the packaged runtime asset bundle"
+        "GroX packaged runtime assets are incomplete or unavailable; "
+        "the installed distribution does not contain the required runtime asset bundle"
     )

--- a/tests/unit/test_installed_runtime.py
+++ b/tests/unit/test_installed_runtime.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+from grox.installation import InstallationError, commission_workspace, installed_vessel_layout
+from grox.runtime_assets import RuntimeAssetError, validate_asset_root
+
+
+class InstalledRuntimeTests(unittest.TestCase):
+    def _asset_root(self, root: Path, *, count: int = 82) -> Path:
+        assets = root / "assets"
+        dossiers = assets / "configs" / "crew" / "dossiers"
+        specialists = assets / "configs" / "crew" / "specialists"
+        dossiers.mkdir(parents=True)
+        specialists.mkdir(parents=True)
+        (assets / "configs" / "tool-policy.json").write_text("{}\n", encoding="utf-8")
+        (assets / "configs" / "crew" / "company-manifest.json").write_text(
+            "{}\n", encoding="utf-8"
+        )
+        for index in range(count):
+            crew_id = f"crew-{index:03d}"
+            (dossiers / f"{crew_id}.json").write_text(
+                json.dumps({"crew_id": crew_id}) + "\n", encoding="utf-8"
+            )
+            (specialists / f"{crew_id}.md").write_text(
+                f"# {crew_id}\n", encoding="utf-8"
+            )
+        return assets
+
+    def test_canonical_source_runtime_assets_validate(self) -> None:
+        root = Path(__file__).resolve().parents[2]
+        self.assertEqual(validate_asset_root(root), root.resolve())
+
+    def test_missing_standing_crew_dossier_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            assets = self._asset_root(Path(td))
+            next((assets / "configs" / "crew" / "dossiers").glob("*.json")).unlink()
+            with self.assertRaisesRegex(RuntimeAssetError, "exactly 82 Standing Crew dossiers"):
+                validate_asset_root(assets)
+
+    def test_malformed_dossier_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            assets = self._asset_root(Path(td))
+            target = next((assets / "configs" / "crew" / "dossiers").glob("*.json"))
+            target.write_text("{not-json", encoding="utf-8")
+            with self.assertRaisesRegex(RuntimeAssetError, "Malformed packaged Crew dossier"):
+                validate_asset_root(assets)
+
+    def test_dossier_and_craft_identity_mismatch_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            assets = self._asset_root(Path(td))
+            target = next((assets / "configs" / "crew" / "specialists").glob("*.md"))
+            target.rename(target.with_name("orphan-craft.md"))
+            with self.assertRaisesRegex(RuntimeAssetError, "Crew/craft identity mismatch"):
+                validate_asset_root(assets)
+
+    def test_dossier_filename_identity_mismatch_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            assets = self._asset_root(Path(td))
+            target = next((assets / "configs" / "crew" / "dossiers").glob("*.json"))
+            target.write_text(json.dumps({"crew_id": "wrong-id"}), encoding="utf-8")
+            with self.assertRaisesRegex(RuntimeAssetError, "dossier identity mismatch"):
+                validate_asset_root(assets)
+
+    def test_installed_layout_requires_commissioned_workspace(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            assets = self._asset_root(root)
+            with self.assertRaisesRegex(InstallationError, "No commissioned GroX workspace"):
+                installed_vessel_layout(
+                    config_dir=root / "config",
+                    system="Linux",
+                    environ={},
+                    home=root / "home",
+                    asset_root=assets,
+                )
+
+    def test_installed_layout_separates_assets_state_and_commander_work(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            assets = self._asset_root(root)
+            workspace = root / "GroX"
+            config = root / "config"
+            commission_workspace(
+                workspace,
+                config_dir=config,
+                system="Linux",
+                environ={},
+                home=root / "home",
+            )
+            layout = installed_vessel_layout(
+                config_dir=config,
+                system="Linux",
+                environ={},
+                home=root / "home",
+                asset_root=assets,
+            )
+            self.assertFalse(layout.legacy_single_root)
+            self.assertEqual(layout.asset_root, assets.resolve())
+            self.assertEqual(layout.state_root, (workspace / "state").resolve())
+            self.assertEqual(layout.work_root, (workspace / "workspace").resolve())
+            self.assertNotEqual(layout.asset_root, layout.state_root)
+            self.assertNotEqual(layout.asset_root, layout.work_root)
+            self.assertNotEqual(layout.state_root, layout.work_root)
+
+    def test_installed_layout_rejects_incomplete_runtime_assets(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            assets = self._asset_root(root, count=81)
+            workspace = root / "GroX"
+            config = root / "config"
+            commission_workspace(workspace, config_dir=config)
+            with self.assertRaisesRegex(InstallationError, "exactly 82 Standing Crew dossiers"):
+                installed_vessel_layout(config_dir=config, asset_root=assets)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Scope

Implements issue #96 from canonical `main@1bfc23e641704f802419b10dac413fbc38666058`.

This is the NCI-1C installation/runtime slice. It does not select a native general-purpose language model, add a desktop launcher, publish a one-command installer, move package/release version, alter the 82-Crew roster, create another orchestrator, or create A8.

## Command invariant

**Commander → Pilot GorXu → Divisions → Standing Crew**

The packaged runtime bundle, filesystem roots, tools, models, installer, and state remain infrastructure/capabilities beneath this hierarchy. Installed operation constructs the same canonical `PilotGorXu` and does not introduce an installed-only Pilot or command plane.

## Candidate implementation

- package the existing canonical `configs/` runtime files directly into wheel data;
- validate policy, company manifest, exactly 82 dossier JSON files, exactly 82 matching craft cards, JSON parseability, and dossier identity before installed startup;
- preserve source-checkout / explicit `GROX_VESSEL_ROOT` developer and recovery operation;
- outside a checkout, resolve the commissioned workspace and packaged assets into the existing NCI-1B `VesselLayout.separated(...)`;
- keep private SQLite state in `<workspace>/state` and Tool Gateway filesystem authority in `<workspace>/workspace`;
- add unit regressions for missing/malformed/mismatched assets and installed layout binding;
- extend Wheel bootstrap qualification to commission/start installed GorXu from `/tmp`, load 82 Crew, run a medium-risk Inspect through `code-reviewer` with independent verification, reopen the same state, and fail closed after deliberate packaged-policy removal;
- add an evidence scaffold that remains explicitly qualification-pending until exact-head CI passes.

## Claim boundary

NCI-1C remains an implementation candidate until exact-head protected CI, review, merge, and source/tree equivalence complete. NCI-1 overall also remains unqualified.

Closes #96 only after qualification and canonical verification.