### PR TITLE
NCI-2A persistent seed-model store foundation

### DIFF
--- a/src/grox/model_store.py
+++ b/src/grox/model_store.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import tempfile
+from dataclasses import asdict, dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Mapping
+
+from .installation import InstallationError, load_workspace_binding
+
+
+class ModelStoreError(RuntimeError):
+    """A persistent local-model store operation is unsafe or invalid."""
+
+
+class ModelArtifactState(str, Enum):
+    MISSING = "MISSING"
+    AVAILABLE = "AVAILABLE"
+    CORRUPT = "CORRUPT"
+
+
+@dataclass(frozen=True, slots=True)
+class ProvisioningSpec:
+    """Attributable identity required before a model artifact may be admitted.
+
+    This contract is intentionally transport-neutral. It contains no downloader
+    and cannot cause network access merely by being constructed or inspected.
+    """
+
+    model_id: str
+    target_filename: str
+    source: str
+    source_revision: str
+    license_id: str
+    sha256: str
+    byte_size: int
+
+    def __post_init__(self) -> None:
+        for field_name in ("model_id", "source", "source_revision", "license_id"):
+            value = getattr(self, field_name)
+            if not isinstance(value, str) or not value.strip():
+                raise ModelStoreError(f"{field_name} must be a non-empty string")
+            object.__setattr__(self, field_name, value.strip())
+
+        target = self.target_filename
+        if not isinstance(target, str) or not target.strip():
+            raise ModelStoreError("target_filename must be a non-empty string")
+        target_path = Path(target.strip())
+        if target_path.is_absolute() or len(target_path.parts) != 1 or target_path.name in {".", ".."}:
+            raise ModelStoreError("target_filename must be one safe filename inside the GroX model store")
+        object.__setattr__(self, "target_filename", target_path.name)
+
+        digest = self.sha256
+        if not isinstance(digest, str) or len(digest) != 64:
+            raise ModelStoreError("sha256 must be a 64-character hexadecimal digest")
+        try:
+            int(digest, 16)
+        except ValueError as exc:
+            raise ModelStoreError("sha256 must be hexadecimal") from exc
+        object.__setattr__(self, "sha256", digest.lower())
+
+        if not isinstance(self.byte_size, int) or isinstance(self.byte_size, bool) or self.byte_size <= 0:
+            raise ModelStoreError("byte_size must be a positive integer")
+
+    @classmethod
+    def from_mapping(cls, raw: Mapping[str, object]) -> "ProvisioningSpec":
+        if not isinstance(raw, Mapping):
+            raise ModelStoreError("model provisioning metadata must be a mapping")
+        return cls(
+            model_id=raw.get("model_id"),  # type: ignore[arg-type]
+            target_filename=raw.get("target_filename"),  # type: ignore[arg-type]
+            source=raw.get("source"),  # type: ignore[arg-type]
+            source_revision=raw.get("source_revision"),  # type: ignore[arg-type]
+            license_id=raw.get("license_id"),  # type: ignore[arg-type]
+            sha256=raw.get("sha256"),  # type: ignore[arg-type]
+            byte_size=raw.get("byte_size"),  # type: ignore[arg-type]
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class ModelArtifactReport:
+    model_id: str
+    state: ModelArtifactState
+    path: str
+    expected_sha256: str
+    observed_sha256: str | None
+    expected_bytes: int
+    observed_bytes: int | None
+    reason: str
+
+    def to_dict(self) -> dict[str, object]:
+        payload = asdict(self)
+        payload["state"] = self.state.value
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class ProvisioningResult:
+    model_id: str
+    status: str
+    path: str
+    sha256: str
+    byte_size: int
+    source: str
+    source_revision: str
+    license_id: str
+    network_used: bool = False
+    authority_changed: bool = False
+    auto_activation: bool = False
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+class PersistentModelStore:
+    """Persistent, non-command model-byte store for a commissioned Vessel.
+
+    The store is deliberately separate from immutable runtime assets and from
+    Commander work. It verifies bytes but does not register, load, activate,
+    route, or grant authority to a model.
+    """
+
+    def __init__(self, root: Path | str):
+        self.root = Path(root).expanduser().resolve()
+        if not self.root.is_dir():
+            raise ModelStoreError(f"GroX model store is unavailable: {self.root}")
+
+    @classmethod
+    def from_workspace(
+        cls,
+        *,
+        config_dir: Path | str | None = None,
+        system: str | None = None,
+        environ: Mapping[str, str] | None = None,
+        home: Path | str | None = None,
+    ) -> "PersistentModelStore":
+        try:
+            workspace = load_workspace_binding(
+                config_dir=config_dir,
+                system=system,
+                environ=environ,
+                home=home,
+                require_marker=True,
+            )
+        except InstallationError as exc:
+            raise ModelStoreError(str(exc)) from exc
+        if workspace is None:
+            raise ModelStoreError("No commissioned GroX workspace found for persistent model storage")
+        model_root = (workspace / "models").resolve()
+        try:
+            model_root.relative_to(workspace)
+        except ValueError as exc:
+            raise ModelStoreError("GroX model store escapes the commissioned workspace") from exc
+        if not model_root.is_dir():
+            raise ModelStoreError(f"Commissioned GroX workspace is missing its model store: {model_root}")
+        return cls(model_root)
+
+    def target(self, spec: ProvisioningSpec) -> Path:
+        target = (self.root / spec.target_filename).resolve()
+        try:
+            target.relative_to(self.root)
+        except ValueError as exc:
+            raise ModelStoreError("model artifact target escapes the GroX model store") from exc
+        return target
+
+    @staticmethod
+    def _digest_file(path: Path) -> tuple[str, int]:
+        digest = hashlib.sha256()
+        size = 0
+        with path.open("rb") as handle:
+            while True:
+                chunk = handle.read(1024 * 1024)
+                if not chunk:
+                    break
+                digest.update(chunk)
+                size += len(chunk)
+        return digest.hexdigest(), size
+
+    def inspect(self, spec: ProvisioningSpec) -> ModelArtifactReport:
+        path = self.target(spec)
+        if not path.is_file():
+            return ModelArtifactReport(
+                model_id=spec.model_id,
+                state=ModelArtifactState.MISSING,
+                path=str(path),
+                expected_sha256=spec.sha256,
+                observed_sha256=None,
+                expected_bytes=spec.byte_size,
+                observed_bytes=None,
+                reason="verified local model artifact is not present",
+            )
+        try:
+            digest, size = self._digest_file(path)
+        except OSError as exc:
+            return ModelArtifactReport(
+                model_id=spec.model_id,
+                state=ModelArtifactState.MISSING,
+                path=str(path),
+                expected_sha256=spec.sha256,
+                observed_sha256=None,
+                expected_bytes=spec.byte_size,
+                observed_bytes=None,
+                reason=f"local model artifact cannot be read: {exc}",
+            )
+        if size != spec.byte_size or digest != spec.sha256:
+            return ModelArtifactReport(
+                model_id=spec.model_id,
+                state=ModelArtifactState.CORRUPT,
+                path=str(path),
+                expected_sha256=spec.sha256,
+                observed_sha256=digest,
+                expected_bytes=spec.byte_size,
+                observed_bytes=size,
+                reason="local model artifact does not match its admitted identity",
+            )
+        return ModelArtifactReport(
+            model_id=spec.model_id,
+            state=ModelArtifactState.AVAILABLE,
+            path=str(path),
+            expected_sha256=spec.sha256,
+            observed_sha256=digest,
+            expected_bytes=spec.byte_size,
+            observed_bytes=size,
+            reason="local model artifact is integrity-bound and available",
+        )
+
+    def provision_from_file(self, spec: ProvisioningSpec, source_path: Path | str) -> ProvisioningResult:
+        """Explicitly admit verified local bytes into the persistent model store.
+
+        The caller is responsible for acquiring `source_path`. This method does
+        not perform network access. Bytes are copied to a private temporary file
+        in the model store, verified there, fsynced, and atomically published.
+        """
+
+        source = Path(source_path).expanduser().resolve()
+        if not source.is_file():
+            raise ModelStoreError(f"model provisioning source is not a file: {source}")
+
+        target = self.target(spec)
+        if target.exists():
+            report = self.inspect(spec)
+            if report.state is ModelArtifactState.AVAILABLE:
+                return ProvisioningResult(
+                    model_id=spec.model_id,
+                    status="existing",
+                    path=str(target),
+                    sha256=spec.sha256,
+                    byte_size=spec.byte_size,
+                    source=spec.source,
+                    source_revision=spec.source_revision,
+                    license_id=spec.license_id,
+                )
+            raise ModelStoreError(f"refusing to overwrite conflicting model artifact: {target}")
+
+        fd, temp_name = tempfile.mkstemp(prefix=f".{target.name}.", suffix=".partial", dir=str(self.root))
+        temp_path = Path(temp_name)
+        digest = hashlib.sha256()
+        size = 0
+        try:
+            with source.open("rb") as source_handle, os.fdopen(fd, "wb") as target_handle:
+                while True:
+                    chunk = source_handle.read(1024 * 1024)
+                    if not chunk:
+                        break
+                    target_handle.write(chunk)
+                    digest.update(chunk)
+                    size += len(chunk)
+                target_handle.flush()
+                os.fsync(target_handle.fileno())
+
+            observed = digest.hexdigest()
+            if size != spec.byte_size:
+                raise ModelStoreError(
+                    f"model artifact byte-size mismatch: expected {spec.byte_size}, got {size}"
+                )
+            if observed != spec.sha256:
+                raise ModelStoreError(
+                    f"model artifact digest mismatch: expected {spec.sha256}, got {observed}"
+                )
+            if target.exists():
+                raise ModelStoreError(f"model artifact target appeared during provisioning: {target}")
+            os.replace(temp_path, target)
+            return ProvisioningResult(
+                model_id=spec.model_id,
+                status="provisioned",
+                path=str(target),
+                sha256=observed,
+                byte_size=size,
+                source=spec.source,
+                source_revision=spec.source_revision,
+                license_id=spec.license_id,
+            )
+        except Exception:
+            temp_path.unlink(missing_ok=True)
+            raise

--- a/src/grox/model_store.py
+++ b/src/grox/model_store.py
@@ -282,9 +282,17 @@ class PersistentModelStore:
                 raise ModelStoreError(
                     f"model artifact digest mismatch: expected {spec.sha256}, got {observed}"
                 )
-            if target.exists():
-                raise ModelStoreError(f"model artifact target appeared during provisioning: {target}")
-            os.replace(temp_path, target)
+            try:
+                os.link(temp_path, target)
+            except FileExistsError as exc:
+                raise ModelStoreError(
+                    f"model artifact target appeared during provisioning: {target}"
+                ) from exc
+            except OSError as exc:
+                raise ModelStoreError(
+                    f"model artifact could not be atomically published: {target}: {exc}"
+                ) from exc
+            temp_path.unlink()
             return ProvisioningResult(
                 model_id=spec.model_id,
                 status="provisioned",

--- a/tests/unit/test_model_store.py
+++ b/tests/unit/test_model_store.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import hashlib
+import tempfile
+import unittest
+from pathlib import Path
+
+from grox.installation import commission_workspace
+from grox.model_store import (
+    ModelArtifactState,
+    ModelStoreError,
+    PersistentModelStore,
+    ProvisioningSpec,
+)
+from grox.native_model_runtime import HardwareRuntimeProfile, LocalModelRuntime, ModelReadiness, ModelRegistry
+from grox.tiny_neural_policy import TINY_MODEL_ID, TinyMLPPythonBackend
+
+
+def _spec(payload: bytes = b"seed-model") -> ProvisioningSpec:
+    return ProvisioningSpec(
+        model_id="seed-model",
+        target_filename="seed-model.gguf",
+        source="https://example.invalid/models/seed-model.gguf",
+        source_revision="revision-pinned-for-test",
+        license_id="Apache-2.0",
+        sha256=hashlib.sha256(payload).hexdigest(),
+        byte_size=len(payload),
+    )
+
+
+class PersistentModelStoreTests(unittest.TestCase):
+    def test_commissioned_workspace_resolves_persistent_model_store(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            workspace = root / "GroX"
+            config = root / "config"
+            commission_workspace(workspace, config_dir=config)
+            store = PersistentModelStore.from_workspace(config_dir=config)
+            self.assertEqual(store.root, (workspace / "models").resolve())
+            self.assertNotEqual(store.root, (workspace / "workspace").resolve())
+            self.assertNotEqual(store.root, (workspace / "state").resolve())
+
+    def test_missing_workspace_or_model_store_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            config = root / "config"
+            with self.assertRaisesRegex(ModelStoreError, "No commissioned GroX workspace"):
+                PersistentModelStore.from_workspace(config_dir=config)
+
+            workspace = root / "GroX"
+            commission_workspace(workspace, config_dir=config)
+            (workspace / "models").rmdir()
+            with self.assertRaisesRegex(ModelStoreError, "missing its model store"):
+                PersistentModelStore.from_workspace(config_dir=config)
+
+    def test_provisioning_metadata_is_explicit_and_path_confined(self) -> None:
+        payload = b"model"
+        digest = hashlib.sha256(payload).hexdigest()
+        with self.assertRaisesRegex(ModelStoreError, "source_revision"):
+            ProvisioningSpec(
+                model_id="seed",
+                target_filename="seed.gguf",
+                source="https://example.invalid/seed.gguf",
+                source_revision="",
+                license_id="Apache-2.0",
+                sha256=digest,
+                byte_size=len(payload),
+            )
+        for unsafe in ("../seed.gguf", "/tmp/seed.gguf", "nested/seed.gguf", "."):
+            with self.subTest(unsafe=unsafe), self.assertRaises(ModelStoreError):
+                ProvisioningSpec(
+                    model_id="seed",
+                    target_filename=unsafe,
+                    source="https://example.invalid/seed.gguf",
+                    source_revision="rev",
+                    license_id="Apache-2.0",
+                    sha256=digest,
+                    byte_size=len(payload),
+                )
+
+    def test_verified_local_import_is_atomic_and_offline_after_provisioning(self) -> None:
+        payload = b"verified seed model bytes"
+        spec = _spec(payload)
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            model_root = root / "models"
+            model_root.mkdir()
+            source = root / "downloaded.gguf"
+            source.write_bytes(payload)
+            store = PersistentModelStore(model_root)
+
+            before = store.inspect(spec)
+            self.assertEqual(before.state, ModelArtifactState.MISSING)
+            result = store.provision_from_file(spec, source)
+            self.assertEqual(result.status, "provisioned")
+            self.assertFalse(result.network_used)
+            self.assertFalse(result.authority_changed)
+            self.assertFalse(result.auto_activation)
+            self.assertEqual(Path(result.path).read_bytes(), payload)
+            self.assertEqual(list(model_root.glob("*.partial")), [])
+
+            source.unlink()
+            after = store.inspect(spec)
+            self.assertEqual(after.state, ModelArtifactState.AVAILABLE)
+            self.assertEqual(after.observed_sha256, spec.sha256)
+            self.assertEqual(after.observed_bytes, spec.byte_size)
+
+    def test_bad_import_never_becomes_ready_and_partial_file_is_removed(self) -> None:
+        expected = b"expected bytes"
+        spec = _spec(expected)
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            model_root = root / "models"
+            model_root.mkdir()
+            source = root / "wrong.gguf"
+            source.write_bytes(b"wrong bytes")
+            store = PersistentModelStore(model_root)
+
+            with self.assertRaisesRegex(ModelStoreError, "byte-size mismatch|digest mismatch"):
+                store.provision_from_file(spec, source)
+            self.assertFalse((model_root / spec.target_filename).exists())
+            self.assertEqual(list(model_root.glob("*.partial")), [])
+            self.assertEqual(store.inspect(spec).state, ModelArtifactState.MISSING)
+
+    def test_corrupt_existing_target_is_not_overwritten(self) -> None:
+        payload = b"expected bytes"
+        spec = _spec(payload)
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            model_root = root / "models"
+            model_root.mkdir()
+            target = model_root / spec.target_filename
+            target.write_bytes(b"conflicting bytes")
+            source = root / "source.gguf"
+            source.write_bytes(payload)
+            store = PersistentModelStore(model_root)
+
+            self.assertEqual(store.inspect(spec).state, ModelArtifactState.CORRUPT)
+            with self.assertRaisesRegex(ModelStoreError, "refusing to overwrite"):
+                store.provision_from_file(spec, source)
+            self.assertEqual(target.read_bytes(), b"conflicting bytes")
+
+    def test_exact_existing_target_is_idempotent_without_activation(self) -> None:
+        payload = b"expected bytes"
+        spec = _spec(payload)
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            model_root = root / "models"
+            model_root.mkdir()
+            source = root / "source.gguf"
+            source.write_bytes(payload)
+            store = PersistentModelStore(model_root)
+            store.provision_from_file(spec, source)
+            second = store.provision_from_file(spec, source)
+            self.assertEqual(second.status, "existing")
+            self.assertFalse(second.network_used)
+            self.assertFalse(second.authority_changed)
+            self.assertFalse(second.auto_activation)
+
+    def test_nci1_packaged_model_runtime_contract_remains_unchanged(self) -> None:
+        source_root = Path(__file__).resolve().parents[2]
+        registry = ModelRegistry.from_asset_root(source_root)
+        self.assertEqual(registry.ids(), (TINY_MODEL_ID,))
+        profile = HardwareRuntimeProfile(
+            system="linux",
+            machine="x86_64",
+            cpu_count=4,
+            total_memory_bytes=32 * 1024 * 1024,
+            accelerators=(),
+            python_implementation="cpython",
+            python_version="3.12.0",
+        )
+        runtime = LocalModelRuntime(registry, [TinyMLPPythonBackend()], hardware=profile)
+        readiness = runtime.readiness(TINY_MODEL_ID)
+        self.assertEqual(readiness.status, ModelReadiness.AVAILABLE)
+        self.assertFalse(readiness.active)
+        self.assertEqual(runtime.active_models(), ())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_model_store.py
+++ b/tests/unit/test_model_store.py
@@ -4,6 +4,7 @@ import hashlib
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from grox.installation import commission_workspace
 from grox.model_store import (
@@ -139,6 +140,23 @@ class PersistentModelStoreTests(unittest.TestCase):
             with self.assertRaisesRegex(ModelStoreError, "refusing to overwrite"):
                 store.provision_from_file(spec, source)
             self.assertEqual(target.read_bytes(), b"conflicting bytes")
+
+    def test_publish_race_fails_closed_without_overwrite_or_partial(self) -> None:
+        payload = b"expected bytes"
+        spec = _spec(payload)
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            model_root = root / "models"
+            model_root.mkdir()
+            source = root / "source.gguf"
+            source.write_bytes(payload)
+            store = PersistentModelStore(model_root)
+
+            with patch("grox.model_store.os.link", side_effect=FileExistsError("raced")):
+                with self.assertRaisesRegex(ModelStoreError, "appeared during provisioning"):
+                    store.provision_from_file(spec, source)
+            self.assertFalse((model_root / spec.target_filename).exists())
+            self.assertEqual(list(model_root.glob("*.partial")), [])
 
     def test_exact_existing_target_is_idempotent_without_activation(self) -> None:
         payload = b"expected bytes"


### PR DESCRIPTION
## Scope

Begin issue #105 from the exact qualified NCI-1 baseline with the smallest persistent model-byte storage/provisioning contract.

This candidate adds:

- a commissioned-workspace `models/` store resolver that remains separate from immutable runtime assets, private state, and Commander work;
- explicit provenance/integrity metadata required before model bytes can be admitted;
- streaming SHA-256 and byte-size verification;
- temporary-file staging with verified publication into the model store;
- fail-closed handling for missing stores, unsafe target names, corrupt/conflicting artifacts, and failed imports;
- offline-after-provisioning inspection with no network code or hidden fetch behavior;
- permanent regression proving the existing NCI-1 packaged tiny-model runtime remains unchanged and non-activating.

## Boundary

This PR does **not** register or qualify Qwen3-4B, add llama.cpp, bind a local GorXu reasoner, implement automatic downloads, qualify NCI-2, move the package/release, change Crew/authority, or create A8.

The primary seed candidate remains recorded in #105 for later qualification work; it is not part of the package or runtime registry in this PR.

Refs #105.