### PR TITLE
NCI-2B pinned local llama.cpp reasoning seam

### DIFF
--- a/src/grox/llama_cpp_backend.py
+++ b/src/grox/llama_cpp_backend.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from .native_model_runtime import HardwareRuntimeProfile, ModelManifest, ModelRuntimeError
+
+
+_VERSION_RE = re.compile(r"version:\s*(?P<version>\d+)\s*\([`']?(?P<commit>[0-9a-fA-F]+)[`']?\)")
+
+
+@dataclass(frozen=True, slots=True)
+class LlamaCppHandle:
+    model_id: str
+    artifact_path: Path
+
+
+class LlamaCppCLIBackend:
+    """Pinned local llama.cpp process backend.
+
+    The backend never downloads models or executables, never searches PATH, and
+    never starts a network server. An explicit local executable and an already
+    verified local GGUF artifact are required before invocation.
+    """
+
+    name = "llama.cpp-cli-b10218"
+
+    def __init__(
+        self,
+        executable: Path | str,
+        *,
+        expected_version: int = 10218,
+        expected_commit_prefix: str = "de69995",
+        context_tokens: int = 4096,
+        max_output_tokens: int = 512,
+        max_threads: int = 4,
+        timeout_seconds: int = 120,
+        max_output_chars: int = 65536,
+        scratch_root: Path | str | None = None,
+    ):
+        path = Path(executable).expanduser()
+        if not path.is_absolute():
+            raise ValueError("llama.cpp executable path must be explicit and absolute")
+        self.executable = path.resolve()
+        if not isinstance(expected_version, int) or isinstance(expected_version, bool) or expected_version <= 0:
+            raise ValueError("expected_version must be a positive integer")
+        commit = expected_commit_prefix.strip().lower()
+        if not commit or not re.fullmatch(r"[0-9a-f]+", commit):
+            raise ValueError("expected_commit_prefix must be hexadecimal")
+        if context_tokens < 512 or context_tokens > 32768:
+            raise ValueError("context_tokens must be between 512 and 32768")
+        if max_output_tokens < 1 or max_output_tokens > 2048:
+            raise ValueError("max_output_tokens must be between 1 and 2048")
+        if max_threads < 1 or max_threads > 64:
+            raise ValueError("max_threads must be between 1 and 64")
+        if timeout_seconds < 1 or timeout_seconds > 900:
+            raise ValueError("timeout_seconds must be between 1 and 900")
+        if max_output_chars < 1024 or max_output_chars > 1024 * 1024:
+            raise ValueError("max_output_chars must be between 1024 and 1048576")
+        self.expected_version = expected_version
+        self.expected_commit_prefix = commit
+        self.context_tokens = context_tokens
+        self.max_output_tokens = max_output_tokens
+        self.max_threads = max_threads
+        self.timeout_seconds = timeout_seconds
+        self.max_output_chars = max_output_chars
+        self.scratch_root = Path(scratch_root).expanduser().resolve() if scratch_root is not None else None
+        self._version_cache: tuple[bool, str] | None = None
+        self.last_command: tuple[str, ...] | None = None
+
+    @staticmethod
+    def _sanitized_environment() -> dict[str, str]:
+        denied_exact = {
+            "HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "NO_PROXY",
+            "http_proxy", "https_proxy", "all_proxy", "no_proxy",
+        }
+        environment: dict[str, str] = {}
+        for key, value in os.environ.items():
+            upper = key.upper()
+            if key in denied_exact or upper.startswith("LLAMA_") or upper.startswith("HF_") or upper.startswith("HUGGING_FACE_"):
+                continue
+            environment[key] = value
+        environment["NO_COLOR"] = "1"
+        environment["TERM"] = "dumb"
+        return environment
+
+    def _probe_version(self) -> tuple[bool, str]:
+        if self._version_cache is not None:
+            return self._version_cache
+        if not self.executable.is_file():
+            self._version_cache = (False, f"llama.cpp executable is unavailable: {self.executable}")
+            return self._version_cache
+        if not os.access(self.executable, os.X_OK):
+            self._version_cache = (False, f"llama.cpp executable is not executable: {self.executable}")
+            return self._version_cache
+        try:
+            completed = subprocess.run(
+                [str(self.executable), "--version"],
+                capture_output=True,
+                text=True,
+                timeout=min(10, self.timeout_seconds),
+                check=False,
+                env=self._sanitized_environment(),
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            self._version_cache = (False, f"llama.cpp version probe failed: {type(exc).__name__}: {exc}")
+            return self._version_cache
+        version_text = (completed.stdout + "\n" + completed.stderr).strip()
+        if completed.returncode != 0:
+            self._version_cache = (False, f"llama.cpp version probe returned {completed.returncode}")
+            return self._version_cache
+        match = _VERSION_RE.search(version_text)
+        if match is None:
+            self._version_cache = (False, "llama.cpp version output did not match the pinned contract")
+            return self._version_cache
+        version = int(match.group("version"))
+        commit = match.group("commit").lower()
+        if version != self.expected_version or not commit.startswith(self.expected_commit_prefix):
+            self._version_cache = (
+                False,
+                "llama.cpp build mismatch: "
+                f"expected={self.expected_version}/{self.expected_commit_prefix}, observed={version}/{commit}",
+            )
+            return self._version_cache
+        self._version_cache = (True, f"pinned llama.cpp build verified: {version}/{commit}")
+        return self._version_cache
+
+    def supports(
+        self, manifest: ModelManifest, hardware: HardwareRuntimeProfile
+    ) -> tuple[bool, str]:
+        del hardware
+        if manifest.backend != self.name:
+            return False, f"manifest backend does not match pinned llama.cpp backend: {manifest.backend}"
+        if manifest.model_format.lower() != "gguf":
+            return False, f"llama.cpp backend requires GGUF, got: {manifest.model_format}"
+        if "gorxu" not in manifest.placements:
+            return False, "local reasoning seed is not registered for GorXu cognition placement"
+        return self._probe_version()
+
+    def load(self, manifest: ModelManifest, artifact_path: Path) -> LlamaCppHandle:
+        supported, reason = self.supports(manifest, HardwareRuntimeProfile.discover())
+        if not supported:
+            raise ModelRuntimeError(reason)
+        path = artifact_path.expanduser().resolve()
+        if not path.is_file():
+            raise ModelRuntimeError(f"GGUF artifact is unavailable: {path}")
+        return LlamaCppHandle(model_id=manifest.model_id, artifact_path=path)
+
+    def invoke(self, handle: LlamaCppHandle, payload: Mapping[str, Any]) -> Mapping[str, Any]:
+        if not isinstance(handle, LlamaCppHandle):
+            raise ModelRuntimeError("llama.cpp handle is invalid")
+        prompt = payload.get("prompt")
+        json_schema = payload.get("json_schema")
+        if not isinstance(prompt, str) or not prompt.strip():
+            raise ModelRuntimeError("llama.cpp invocation requires a non-empty prompt")
+        if not isinstance(json_schema, Mapping):
+            raise ModelRuntimeError("llama.cpp invocation requires a JSON-schema mapping")
+        if len(prompt) > 131072:
+            raise ModelRuntimeError("llama.cpp prompt exceeds the bounded character ceiling")
+
+        schema_text = json.dumps(dict(json_schema), ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+        threads = min(self.max_threads, max(1, int(os.cpu_count() or 1)))
+        temp_dir = str(self.scratch_root) if self.scratch_root is not None else None
+        prompt_path: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                encoding="utf-8",
+                prefix="grox-llama-prompt-",
+                suffix=".txt",
+                dir=temp_dir,
+                delete=False,
+            ) as prompt_file:
+                prompt_file.write(prompt)
+                prompt_file.flush()
+                os.fsync(prompt_file.fileno())
+                prompt_path = Path(prompt_file.name)
+            os.chmod(prompt_path, 0o600)
+
+            command = [
+                str(self.executable),
+                "-m", str(handle.artifact_path),
+                "-f", str(prompt_path),
+                "-j", schema_text,
+                "--single-turn",
+                "--no-display-prompt",
+                "--no-warmup",
+                "--temp", "0",
+                "--seed", "1",
+                "--ctx-size", str(self.context_tokens),
+                "-n", str(self.max_output_tokens),
+                "-t", str(threads),
+                "-ngl", "0",
+            ]
+            self.last_command = tuple(command)
+            try:
+                completed = subprocess.run(
+                    command,
+                    capture_output=True,
+                    text=True,
+                    timeout=self.timeout_seconds,
+                    check=False,
+                    env=self._sanitized_environment(),
+                )
+            except subprocess.TimeoutExpired as exc:
+                raise ModelRuntimeError(f"llama.cpp inference timed out after {self.timeout_seconds}s") from exc
+            except OSError as exc:
+                raise ModelRuntimeError(f"llama.cpp inference process failed to start: {exc}") from exc
+            if completed.returncode != 0:
+                detail = completed.stderr.strip()[:2000]
+                raise ModelRuntimeError(
+                    f"llama.cpp inference returned {completed.returncode}: {detail}"
+                )
+            text = completed.stdout.strip()
+            if not text:
+                raise ModelRuntimeError("llama.cpp inference returned no stdout")
+            if len(text) > self.max_output_chars:
+                raise ModelRuntimeError("llama.cpp inference output exceeded the bounded character ceiling")
+            return {
+                "text": text,
+                "backend_version": self.expected_version,
+                "backend_commit_prefix": self.expected_commit_prefix,
+                "network_used": False,
+                "authority_changed": False,
+                "cpu_only": True,
+            }
+        finally:
+            if prompt_path is not None:
+                prompt_path.unlink(missing_ok=True)
+
+    def unload(self, handle: LlamaCppHandle) -> None:
+        if not isinstance(handle, LlamaCppHandle):
+            raise ModelRuntimeError("llama.cpp handle is invalid")

--- a/src/grox/native_model_runtime.py
+++ b/src/grox/native_model_runtime.py
@@ -84,8 +84,8 @@ class ModelArtifact:
         normalized = Path(path.strip())
         if normalized.is_absolute() or ".." in normalized.parts:
             raise ModelRegistrationError("model artifact path must remain relative to its registered GroX storage root")
-        if location not in {"runtime_assets", "persistent_model_store"}:
-            raise ModelRegistrationError(f"unsupported model artifact location: {location}")
+        if not isinstance(location, str) or location not in {"runtime_assets", "persistent_model_store"}:
+            raise ModelRegistrationError(f"unsupported model artifact location: {location!r}")
         if not isinstance(digest, str) or len(digest) != 64:
             raise ModelRegistrationError("model artifact sha256 must be a 64-character hexadecimal digest")
         try:

--- a/src/grox/native_model_runtime.py
+++ b/src/grox/native_model_runtime.py
@@ -69,6 +69,7 @@ class ModelArtifact:
     path: str
     sha256: str
     byte_size: int
+    location: str = "runtime_assets"
 
     @classmethod
     def from_mapping(cls, raw: Mapping[str, Any]) -> "ModelArtifact":
@@ -77,11 +78,14 @@ class ModelArtifact:
         path = raw.get("path")
         digest = raw.get("sha256")
         byte_size = raw.get("bytes")
+        location = raw.get("location", "runtime_assets")
         if not isinstance(path, str) or not path.strip():
             raise ModelRegistrationError("model artifact path must be a non-empty string")
         normalized = Path(path.strip())
         if normalized.is_absolute() or ".." in normalized.parts:
-            raise ModelRegistrationError("model artifact path must remain relative to the GroX asset root")
+            raise ModelRegistrationError("model artifact path must remain relative to its registered GroX storage root")
+        if location not in {"runtime_assets", "persistent_model_store"}:
+            raise ModelRegistrationError(f"unsupported model artifact location: {location}")
         if not isinstance(digest, str) or len(digest) != 64:
             raise ModelRegistrationError("model artifact sha256 must be a 64-character hexadecimal digest")
         try:
@@ -90,15 +94,32 @@ class ModelArtifact:
             raise ModelRegistrationError("model artifact sha256 must be hexadecimal") from exc
         if not isinstance(byte_size, int) or isinstance(byte_size, bool) or byte_size <= 0:
             raise ModelRegistrationError("model artifact bytes must be a positive integer")
-        return cls(path=normalized.as_posix(), sha256=digest.lower(), byte_size=byte_size)
+        return cls(
+            path=normalized.as_posix(),
+            sha256=digest.lower(),
+            byte_size=byte_size,
+            location=location,
+        )
 
-    def resolve(self, asset_root: Path | str) -> Path:
-        root = Path(asset_root).expanduser().resolve()
+    def resolve(
+        self,
+        asset_root: Path | str,
+        *,
+        model_store_root: Path | str | None = None,
+    ) -> Path:
+        if self.location == "runtime_assets":
+            root = Path(asset_root).expanduser().resolve()
+            root_label = "GroX asset root"
+        else:
+            if model_store_root is None:
+                raise ModelRegistrationError("persistent model artifact requires an explicit GroX model-store root")
+            root = Path(model_store_root).expanduser().resolve()
+            root_label = "GroX model-store root"
         target = (root / self.path).resolve()
         try:
             target.relative_to(root)
         except ValueError as exc:
-            raise ModelRegistrationError("model artifact path escapes the GroX asset root") from exc
+            raise ModelRegistrationError(f"model artifact path escapes the {root_label}") from exc
         return target
 
 
@@ -139,7 +160,7 @@ class ModelManifest:
     def from_mapping(cls, raw: Mapping[str, Any]) -> "ModelManifest":
         if not isinstance(raw, Mapping):
             raise ModelRegistrationError("model manifest must be a mapping")
-        required_strings = {}
+        required_strings: dict[str, str] = {}
         for key in ("model_id", "model_kind", "format", "backend"):
             value = raw.get(key)
             if not isinstance(value, str) or not value.strip():
@@ -248,8 +269,17 @@ class ModelRegistry:
 
     schema = "grox-model-registry-v1"
 
-    def __init__(self, *, asset_root: Path | str, manifests: list[ModelManifest]):
+    def __init__(
+        self,
+        *,
+        asset_root: Path | str,
+        manifests: list[ModelManifest],
+        model_store_root: Path | str | None = None,
+    ):
         self.asset_root = Path(asset_root).expanduser().resolve()
+        self.model_store_root = (
+            Path(model_store_root).expanduser().resolve() if model_store_root is not None else None
+        )
         by_id: dict[str, ModelManifest] = {}
         for manifest in manifests:
             if manifest.model_id in by_id:
@@ -260,7 +290,11 @@ class ModelRegistry:
 
     @classmethod
     def from_mapping(
-        cls, *, asset_root: Path | str, raw: Mapping[str, Any]
+        cls,
+        *,
+        asset_root: Path | str,
+        raw: Mapping[str, Any],
+        model_store_root: Path | str | None = None,
     ) -> "ModelRegistry":
         if not isinstance(raw, Mapping) or raw.get("schema") != cls.schema:
             raise ModelRegistrationError(f"model registry schema must be {cls.schema}")
@@ -269,11 +303,17 @@ class ModelRegistry:
             raise ModelRegistrationError("model registry models must be a list")
         return cls(
             asset_root=asset_root,
+            model_store_root=model_store_root,
             manifests=[ModelManifest.from_mapping(item) for item in models],
         )
 
     @classmethod
-    def from_asset_root(cls, asset_root: Path | str) -> "ModelRegistry":
+    def from_asset_root(
+        cls,
+        asset_root: Path | str,
+        *,
+        model_store_root: Path | str | None = None,
+    ) -> "ModelRegistry":
         root = Path(asset_root).expanduser().resolve()
         path = root / "configs" / "models" / "registry.json"
         try:
@@ -282,7 +322,7 @@ class ModelRegistry:
             raise ModelRegistrationError(f"model registry is unavailable: {path}") from exc
         except (OSError, json.JSONDecodeError) as exc:
             raise ModelRegistrationError(f"model registry is malformed: {path}: {exc}") from exc
-        return cls.from_mapping(asset_root=root, raw=raw)
+        return cls.from_mapping(asset_root=root, model_store_root=model_store_root, raw=raw)
 
     def ids(self) -> tuple[str, ...]:
         return tuple(sorted(self._manifests))
@@ -292,6 +332,12 @@ class ModelRegistry:
             return self._manifests[model_id]
         except KeyError as exc:
             raise ModelRegistrationError(f"model is not registered: {model_id}") from exc
+
+    def artifact_path(self, manifest: ModelManifest) -> Path:
+        return manifest.artifact.resolve(
+            self.asset_root,
+            model_store_root=self.model_store_root,
+        )
 
     def _validate_lineage(self) -> None:
         for manifest in self._manifests.values():
@@ -368,23 +414,41 @@ class LocalModelRuntime:
     def active_models(self) -> tuple[str, ...]:
         return tuple(sorted(self._loaded))
 
+    @staticmethod
+    def _digest_artifact(path: Path) -> tuple[str, int]:
+        digest = hashlib.sha256()
+        size = 0
+        with path.open("rb") as handle:
+            while True:
+                chunk = handle.read(1024 * 1024)
+                if not chunk:
+                    break
+                digest.update(chunk)
+                size += len(chunk)
+        return digest.hexdigest(), size
+
     def readiness(self, model_id: str) -> ModelReadinessReport:
         try:
             manifest = self.registry.get(model_id)
+            artifact_path = self.registry.artifact_path(manifest)
         except ModelRegistrationError as exc:
+            manifest = None
+            try:
+                manifest = self.registry.get(model_id)
+            except ModelRegistrationError:
+                pass
             return ModelReadinessReport(
                 model_id=model_id,
                 status=ModelReadiness.UNAVAILABLE,
                 reason=str(exc),
-                backend=None,
-                placement_options=(),
+                backend=manifest.backend if manifest is not None else None,
+                placement_options=manifest.placements if manifest is not None else (),
                 artifact_path=None,
                 artifact_sha256=None,
                 hardware=self.hardware,
                 active=False,
             )
 
-        artifact_path = manifest.artifact.resolve(self.registry.asset_root)
         active = model_id in self._loaded
         if not artifact_path.is_file():
             return self._report(
@@ -395,7 +459,7 @@ class LocalModelRuntime:
                 active,
             )
         try:
-            data = artifact_path.read_bytes()
+            digest, size = self._digest_artifact(artifact_path)
         except OSError as exc:
             return self._report(
                 manifest,
@@ -404,12 +468,11 @@ class LocalModelRuntime:
                 artifact_path,
                 active,
             )
-        digest = hashlib.sha256(data).hexdigest()
-        if len(data) != manifest.artifact.byte_size:
+        if size != manifest.artifact.byte_size:
             return self._report(
                 manifest,
                 ModelReadiness.CORRUPT,
-                f"model artifact byte-size mismatch: expected {manifest.artifact.byte_size}, got {len(data)}",
+                f"model artifact byte-size mismatch: expected {manifest.artifact.byte_size}, got {size}",
                 artifact_path,
                 active,
                 digest=digest,
@@ -505,7 +568,7 @@ class LocalModelRuntime:
                 f"model {model_id} is not ready: {report.status.value}: {report.reason}"
             )
         backend = self.backends[manifest.backend]
-        artifact_path = manifest.artifact.resolve(self.registry.asset_root)
+        artifact_path = self.registry.artifact_path(manifest)
         try:
             handle = backend.load(manifest, artifact_path)
         except Exception as exc:

--- a/src/grox/reasoning/local_llama_cpp.py
+++ b/src/grox/reasoning/local_llama_cpp.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from .base import CognitiveUsage, ReasoningError
+from .contracts import MissionInterpretation
+from ..native_model_runtime import LocalModelRuntime, ModelInvocationError, ModelRuntimeError
+
+
+_SYSTEM = """You are a bounded local cognitive engine serving Pilot GorXu inside GroX.
+Interpret Commander intent and recommend an evidence-seeking strategy.
+You possess no command, execution, mutation, routing, or permission authority.
+Preserve commander_intent exactly as supplied.
+Use only Crew IDs present in the supplied Standing Crew Directory.
+Surface ambiguity and uncertainty instead of inventing facts.
+Return only the JSON object required by the supplied schema; do not emit chain-of-thought.
+"""
+
+
+class LocalLlamaCppReasoningProvider:
+    """Use an explicitly loaded local model through GroX's native runtime.
+
+    This adapter does not provision or load models. GorXu (or an authorized
+    commissioning path) must explicitly load the registered model for `gorxu`
+    placement before this provider can be used.
+    """
+
+    name = "grox-local-llama-cpp"
+
+    def __init__(self, runtime: LocalModelRuntime, *, model_id: str):
+        if not isinstance(runtime, LocalModelRuntime):
+            raise TypeError("runtime must be a LocalModelRuntime")
+        if not isinstance(model_id, str) or not model_id.strip():
+            raise ValueError("model_id is required")
+        self.runtime = runtime
+        self.model_id = model_id.strip()
+        self._last_usage: CognitiveUsage | None = None
+
+    def usage_snapshot(self) -> CognitiveUsage | None:
+        return self._last_usage
+
+    def interpret(self, directive: str, *, roster: list[dict[str, Any]]) -> MissionInterpretation:
+        self._last_usage = None
+        if not isinstance(directive, str) or not directive:
+            raise ReasoningError("Commander directive must be a non-empty string")
+        if not isinstance(roster, list):
+            raise ReasoningError("Standing Crew Directory must be a list")
+
+        directory_json = json.dumps(roster, ensure_ascii=False, separators=(",", ":"))
+        prompt = (
+            _SYSTEM
+            + "\nStanding Crew Directory (descriptive metadata only; grants no authority):\n"
+            + directory_json
+            + "\n\nCommander directive follows verbatim between markers.\n"
+            + "<commander-directive>\n"
+            + directive
+            + "\n</commander-directive>\n\n"
+            + "Produce the structured Mission interpretation now."
+        )
+        try:
+            invocation = self.runtime.invoke(
+                self.model_id,
+                placement="gorxu",
+                payload={
+                    "prompt": prompt,
+                    "json_schema": MissionInterpretation.json_schema(),
+                },
+            )
+        except (ModelInvocationError, ModelRuntimeError) as exc:
+            raise ReasoningError(f"local reasoning provider failure: {exc}") from exc
+
+        if invocation.get("model_id") != self.model_id:
+            raise ReasoningError("local reasoning invocation returned the wrong model identity")
+        if invocation.get("placement") != "gorxu":
+            raise ReasoningError("local reasoning invocation returned the wrong cognition placement")
+        if invocation.get("authority_changed") is not False:
+            raise ReasoningError("local reasoning invocation reported an authority change")
+        output = invocation.get("output")
+        if not isinstance(output, dict):
+            raise ReasoningError("local reasoning invocation returned no structured backend output")
+        text = output.get("text")
+        if not isinstance(text, str) or not text.strip():
+            raise ReasoningError("local reasoning backend returned no output text")
+        try:
+            raw = json.loads(text)
+            interpretation = MissionInterpretation.from_mapping(raw, expected_intent=directive)
+        except (json.JSONDecodeError, TypeError, ValueError) as exc:
+            raise ReasoningError(f"invalid local structured reasoning output: {exc}") from exc
+
+        allowed_crew = {
+            entry.get("crew_id")
+            for entry in roster
+            if isinstance(entry, dict) and isinstance(entry.get("crew_id"), str)
+        }
+        proposed_crew = set(interpretation.candidate_crew_ids)
+        for option in interpretation.options:
+            proposed_crew.update(option.crew_ids)
+        unknown = sorted(crew_id for crew_id in proposed_crew if crew_id not in allowed_crew)
+        if unknown:
+            raise ReasoningError(
+                "local reasoning output referenced Crew outside the supplied Standing Crew Directory: "
+                + ", ".join(unknown)
+            )
+
+        self._last_usage = CognitiveUsage(provider=self.name, model=self.model_id)
+        return interpretation

--- a/tests/unit/test_nci2_local_llama.py
+++ b/tests/unit/test_nci2_local_llama.py
@@ -1,0 +1,301 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from grox.llama_cpp_backend import LlamaCppCLIBackend
+from grox.native_model_runtime import (
+    HardwareRuntimeProfile,
+    LocalModelRuntime,
+    ModelArtifact,
+    ModelReadiness,
+    ModelRegistry,
+)
+from grox.reasoning.base import ReasoningError
+from grox.reasoning.local_llama_cpp import LocalLlamaCppReasoningProvider
+from grox.tiny_neural_policy import TINY_MODEL_ID, TinyMLPPythonBackend
+
+
+_DIRECTIVE = "Inspect the repository and identify the highest-risk reliability gap."
+_ROSTER = [
+    {"crew_id": "architect", "division": "Engineering", "title": "Architect", "domains": ["architecture"], "verification": False},
+    {"crew_id": "code-reviewer", "division": "Assurance", "title": "Code Reviewer", "domains": ["code review"], "verification": True},
+]
+
+
+def _hardware() -> HardwareRuntimeProfile:
+    return HardwareRuntimeProfile(
+        system="linux",
+        machine="x86_64",
+        cpu_count=8,
+        total_memory_bytes=16 * 1024 * 1024 * 1024,
+        accelerators=(),
+        python_implementation="cpython",
+        python_version="3.12.0",
+    )
+
+
+def _write_fake_cli(root: Path, *, mode: str = "valid", version: str = "version: 10218 (de699957b)") -> Path:
+    path = root / f"llama-cli-{mode}"
+    script = f'''#!/usr/bin/env python3
+import json
+import pathlib
+import sys
+import time
+
+if "--version" in sys.argv:
+    print({version!r})
+    raise SystemExit(0)
+
+mode = {mode!r}
+if mode == "timeout":
+    time.sleep(2)
+    raise SystemExit(0)
+if mode == "nonzero":
+    print("simulated backend failure", file=sys.stderr)
+    raise SystemExit(7)
+
+args = sys.argv[1:]
+prompt_path = pathlib.Path(args[args.index("-f") + 1])
+prompt = prompt_path.read_text(encoding="utf-8")
+start = prompt.index("<commander-directive>\\n") + len("<commander-directive>\\n")
+end = prompt.index("\\n</commander-directive>")
+directive = prompt[start:end]
+
+if mode == "malformed":
+    print("not-json")
+    raise SystemExit(0)
+if mode == "drift":
+    directive = "changed intent"
+if mode == "unknown-crew":
+    crew = ["ghost-crew"]
+else:
+    crew = ["architect"]
+
+payload = {{
+    "commander_intent": directive,
+    "objective": "Identify the highest-risk reliability gap.",
+    "ambiguous": False,
+    "ambiguities": [],
+    "assumptions": [],
+    "information_needs": ["repository evidence"],
+    "candidate_crew_ids": crew,
+    "options": [
+        {{
+            "name": "inspect",
+            "rationale": "Gather bounded evidence before proposing change.",
+            "advantages": ["evidence first"],
+            "risks": ["inspection may be incomplete"],
+            "crew_ids": crew,
+        }}
+    ],
+    "recommended_option": "inspect",
+    "confidence": 0.8,
+    "proposed_mode": "inspect",
+    "proposed_risk": "medium",
+}}
+print(json.dumps(payload, separators=(",", ":")))
+'''
+    path.write_text(textwrap.dedent(script), encoding="utf-8")
+    path.chmod(0o755)
+    return path
+
+
+def _runtime(root: Path, executable: Path) -> tuple[LocalModelRuntime, LlamaCppCLIBackend, str]:
+    asset_root = root / "assets"
+    model_root = root / "models"
+    asset_root.mkdir()
+    model_root.mkdir()
+    artifact = b"fake-gguf-model"
+    (model_root / "seed.gguf").write_bytes(artifact)
+    model_id = "nci2-seed-test"
+    backend = LlamaCppCLIBackend(
+        executable,
+        timeout_seconds=1,
+        scratch_root=root / "scratch",
+    )
+    (root / "scratch").mkdir()
+    raw = {
+        "schema": "grox-model-registry-v1",
+        "models": [
+            {
+                "model_id": model_id,
+                "model_kind": "language-seed-candidate",
+                "format": "gguf",
+                "backend": backend.name,
+                "artifact": {
+                    "location": "persistent_model_store",
+                    "path": "seed.gguf",
+                    "sha256": hashlib.sha256(artifact).hexdigest(),
+                    "bytes": len(artifact),
+                },
+                "lineage": {"generation": 1, "parent_model_id": None},
+                "placements": ["gorxu"],
+                "parameter_count": 4_000_000_000,
+                "resources": {"min_ram_bytes": 0, "required_accelerator": None},
+                "provenance": {"source": "unit-test", "license": "Apache-2.0"},
+                "claims": {"qualified": False},
+            }
+        ],
+    }
+    registry = ModelRegistry.from_mapping(
+        asset_root=asset_root,
+        model_store_root=model_root,
+        raw=raw,
+    )
+    return LocalModelRuntime(registry, [backend], hardware=_hardware()), backend, model_id
+
+
+class NCI2ArtifactLocationTests(unittest.TestCase):
+    def test_legacy_artifact_location_defaults_to_runtime_assets(self) -> None:
+        artifact = ModelArtifact.from_mapping(
+            {"path": "configs/models/model.json", "sha256": "0" * 64, "bytes": 1}
+        )
+        self.assertEqual(artifact.location, "runtime_assets")
+
+    def test_existing_nci1_registry_and_tiny_backend_remain_unchanged(self) -> None:
+        source_root = Path(__file__).resolve().parents[2]
+        registry = ModelRegistry.from_asset_root(source_root)
+        self.assertEqual(registry.ids(), (TINY_MODEL_ID,))
+        self.assertEqual(registry.get(TINY_MODEL_ID).artifact.location, "runtime_assets")
+        runtime = LocalModelRuntime(registry, [TinyMLPPythonBackend()], hardware=_hardware())
+        self.assertEqual(runtime.readiness(TINY_MODEL_ID).status, ModelReadiness.AVAILABLE)
+        self.assertEqual(runtime.active_models(), ())
+
+    def test_persistent_artifact_requires_explicit_store_root(self) -> None:
+        raw = {
+            "schema": "grox-model-registry-v1",
+            "models": [{
+                "model_id": "seed",
+                "model_kind": "candidate",
+                "format": "gguf",
+                "backend": "missing-backend",
+                "artifact": {"location": "persistent_model_store", "path": "seed.gguf", "sha256": "0" * 64, "bytes": 1},
+                "lineage": {"generation": 1, "parent_model_id": None},
+                "placements": ["gorxu"],
+                "parameter_count": None,
+                "resources": {"min_ram_bytes": 0, "required_accelerator": None},
+                "provenance": {},
+                "claims": {},
+            }],
+        }
+        with tempfile.TemporaryDirectory() as td:
+            registry = ModelRegistry.from_mapping(asset_root=td, raw=raw)
+            runtime = LocalModelRuntime(registry, [], hardware=_hardware())
+            report = runtime.readiness("seed")
+            self.assertEqual(report.status, ModelReadiness.UNAVAILABLE)
+            self.assertIn("model-store root", report.reason)
+
+    def test_large_artifact_integrity_is_streamed_not_read_bytes(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            cli = _write_fake_cli(root)
+            runtime, _, model_id = _runtime(root, cli)
+            with patch.object(Path, "read_bytes", side_effect=AssertionError("read_bytes must not be used")):
+                self.assertEqual(runtime.readiness(model_id).status, ModelReadiness.AVAILABLE)
+
+
+class LlamaCppBackendTests(unittest.TestCase):
+    def test_pinned_cli_load_and_invoke_is_local_bounded_and_non_activating_until_load(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            cli = _write_fake_cli(root)
+            runtime, backend, model_id = _runtime(root, cli)
+            self.assertEqual(runtime.active_models(), ())
+            self.assertEqual(runtime.readiness(model_id).status, ModelReadiness.AVAILABLE)
+            load = runtime.load(model_id, placement="gorxu")
+            self.assertFalse(load["authority_changed"])
+            self.assertEqual(runtime.active_models(), (model_id,))
+
+            provider = LocalLlamaCppReasoningProvider(runtime, model_id=model_id)
+            result = provider.interpret(_DIRECTIVE, roster=_ROSTER)
+            self.assertEqual(result.commander_intent, _DIRECTIVE)
+            self.assertEqual(result.candidate_crew_ids, ["architect"])
+            self.assertIsNotNone(provider.usage_snapshot())
+            self.assertEqual(provider.usage_snapshot().model, model_id)
+
+            command = backend.last_command
+            self.assertIsNotNone(command)
+            joined = " ".join(command or ())
+            self.assertNotIn("-hf", command or ())
+            self.assertNotIn("http://", joined)
+            self.assertNotIn("https://", joined)
+            self.assertNotIn(_DIRECTIVE, joined)
+            self.assertIn("-ngl", command or ())
+            self.assertEqual((command or ())[list(command or ()).index("-ngl") + 1], "0")
+            prompt_path = Path((command or ())[list(command or ()).index("-f") + 1])
+            self.assertFalse(prompt_path.exists())
+
+            reconstituted = runtime.reconstitute()
+            self.assertEqual(reconstituted["active_after"], [])
+            self.assertFalse(reconstituted["auto_activation"])
+            self.assertFalse(reconstituted["authority_changed"])
+
+    def test_wrong_pinned_version_is_unsupported(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            cli = _write_fake_cli(root, version="version: 10217 (aaaaaaaa)")
+            runtime, _, model_id = _runtime(root, cli)
+            report = runtime.readiness(model_id)
+            self.assertEqual(report.status, ModelReadiness.UNSUPPORTED)
+            self.assertIn("build mismatch", report.reason)
+
+    def test_missing_or_non_executable_cli_is_unsupported(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            missing = (root / "missing-llama-cli").resolve()
+            runtime, _, model_id = _runtime(root, missing)
+            self.assertEqual(runtime.readiness(model_id).status, ModelReadiness.UNSUPPORTED)
+
+            cli = _write_fake_cli(root)
+            cli.chmod(0o644)
+            runtime2, _, model_id2 = _runtime(root / "second", cli)
+            self.assertEqual(runtime2.readiness(model_id2).status, ModelReadiness.UNSUPPORTED)
+
+    def test_timeout_and_nonzero_exit_are_contained(self) -> None:
+        for mode, expected in (("timeout", "timed out"), ("nonzero", "returned 7")):
+            with self.subTest(mode=mode), tempfile.TemporaryDirectory() as td:
+                root = Path(td)
+                cli = _write_fake_cli(root, mode=mode)
+                runtime, _, model_id = _runtime(root, cli)
+                runtime.load(model_id, placement="gorxu")
+                provider = LocalLlamaCppReasoningProvider(runtime, model_id=model_id)
+                with self.assertRaisesRegex(ReasoningError, expected):
+                    provider.interpret(_DIRECTIVE, roster=_ROSTER)
+
+
+class LocalLlamaReasoningProviderTests(unittest.TestCase):
+    def test_provider_requires_explicit_model_load(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            runtime, _, model_id = _runtime(root, _write_fake_cli(root))
+            provider = LocalLlamaCppReasoningProvider(runtime, model_id=model_id)
+            with self.assertRaisesRegex(ReasoningError, "not explicitly loaded"):
+                provider.interpret(_DIRECTIVE, roster=_ROSTER)
+            self.assertEqual(runtime.active_models(), ())
+
+    def test_malformed_output_intent_drift_and_unknown_crew_fail_closed(self) -> None:
+        cases = (
+            ("malformed", "invalid local structured reasoning output"),
+            ("drift", "preserve Commander intent verbatim"),
+            ("unknown-crew", "outside the supplied Standing Crew Directory"),
+        )
+        for mode, expected in cases:
+            with self.subTest(mode=mode), tempfile.TemporaryDirectory() as td:
+                root = Path(td)
+                runtime, _, model_id = _runtime(root, _write_fake_cli(root, mode=mode))
+                runtime.load(model_id, placement="gorxu")
+                provider = LocalLlamaCppReasoningProvider(runtime, model_id=model_id)
+                with self.assertRaisesRegex(ReasoningError, expected):
+                    provider.interpret(_DIRECTIVE, roster=_ROSTER)
+                self.assertIsNone(provider.usage_snapshot())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_nci2_local_llama.py
+++ b/tests/unit/test_nci2_local_llama.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import hashlib
-import json
-import os
 import tempfile
 import textwrap
 import unittest
@@ -15,6 +13,7 @@ from grox.native_model_runtime import (
     LocalModelRuntime,
     ModelArtifact,
     ModelReadiness,
+    ModelRegistrationError,
     ModelRegistry,
 )
 from grox.reasoning.base import ReasoningError
@@ -42,6 +41,7 @@ def _hardware() -> HardwareRuntimeProfile:
 
 
 def _write_fake_cli(root: Path, *, mode: str = "valid", version: str = "version: 10218 (de699957b)") -> Path:
+    root.mkdir(parents=True, exist_ok=True)
     path = root / f"llama-cli-{mode}"
     script = f'''#!/usr/bin/env python3
 import json
@@ -108,6 +108,7 @@ print(json.dumps(payload, separators=(",", ":")))
 
 
 def _runtime(root: Path, executable: Path) -> tuple[LocalModelRuntime, LlamaCppCLIBackend, str]:
+    root.mkdir(parents=True, exist_ok=True)
     asset_root = root / "assets"
     model_root = root / "models"
     asset_root.mkdir()
@@ -158,6 +159,12 @@ class NCI2ArtifactLocationTests(unittest.TestCase):
             {"path": "configs/models/model.json", "sha256": "0" * 64, "bytes": 1}
         )
         self.assertEqual(artifact.location, "runtime_assets")
+
+    def test_invalid_artifact_location_type_fails_as_registration_error(self) -> None:
+        with self.assertRaisesRegex(ModelRegistrationError, "artifact location"):
+            ModelArtifact.from_mapping(
+                {"location": ["persistent_model_store"], "path": "model.gguf", "sha256": "0" * 64, "bytes": 1}
+            )
 
     def test_existing_nci1_registry_and_tiny_backend_remain_unchanged(self) -> None:
         source_root = Path(__file__).resolve().parents[2]


### PR DESCRIPTION
## Scope

Implement issue #107 as a bounded NCI-2B candidate from canonical NCI-2A.

This PR:

- extends model artifacts with a backward-compatible `runtime_assets` location plus explicit `persistent_model_store` resolution;
- changes artifact integrity verification from whole-file `read_bytes()` to bounded streaming SHA-256/size verification for multi-GB seed artifacts;
- adds an explicit-path, pinned llama.cpp CLI backend contract for b10218 / `de69995`;
- uses direct local subprocess inference only: no `-hf`, downloader, remote endpoint, API credential, PATH discovery, or long-running server;
- applies bounded CPU-first CLI controls and sanitizes model/network-related environment overrides;
- keeps Commander text out of argv via a mode-0600 temporary prompt file deleted after invocation;
- adds a local `ReasoningProvider` that requests the existing `MissionInterpretation` JSON schema and reuses the existing verbatim Commander-intent validation;
- requires explicit `LocalModelRuntime.load(... placement="gorxu")` before the reasoning provider can invoke a model;
- keeps reconstitution non-activating and all model output subordinate to existing deterministic GroX authority controls.

## Evidence boundary

The tests use a controlled fake pinned `llama-cli` executable and a tiny fake GGUF artifact to prove the integration contract. This is **not live Qwen evidence** and does not qualify NCI-2.

Qwen3-4B Q4_K_M remains the primary NCI-2 seed candidate for a later live/offline gate.

## Non-goals

No Qwen registration/download/live inference, no automatic provider replacement, no model promotion/activation, no Crew/authority/command-layer change, no package/release movement, no public installer/desktop launcher, and no A8.

Refs #107.