### PR TITLE
Live Environment Awareness: governed remote cognition transport freshness

### DIFF
--- a/src/grox/cognition_awareness.py
+++ b/src/grox/cognition_awareness.py
@@ -1,16 +1,21 @@
 from __future__ import annotations
 
+from collections.abc import Callable, MutableMapping
 from dataclasses import dataclass
 import hashlib
 import re
+from time import monotonic
 from typing import Any
 from urllib.parse import urlsplit, urlunsplit
 
+from .contracts import MissionOrder
 from .native_model_runtime import LocalModelRuntime
 from .openai_crew_cognition import OpenAICrewCognitionProvider
 from .reasoning.openai_responses import OpenAIResponsesProvider
 from .reasoning.session import SessionReasoningProvider
 from .session_crew_cognition import SessionCrewCognitionProvider
+from .tools.gateway import ToolDenied, ToolGateway
+from .tools.policy import PolicyError, normalize_origin
 
 
 _HOSTED_TYPES = (
@@ -19,6 +24,12 @@ _HOSTED_TYPES = (
     OpenAIResponsesProvider,
     OpenAICrewCognitionProvider,
 )
+_REMOTE_TYPES = (OpenAIResponsesProvider, OpenAICrewCognitionProvider)
+_SESSION_TYPES = (SessionReasoningProvider, SessionCrewCognitionProvider)
+
+
+class CognitionTransportAuthorizationError(PermissionError):
+    """The bounded cognition transport probe lacks exact sealed authority."""
 
 
 def _validate_ids(values: frozenset[str], *, field: str) -> frozenset[str]:
@@ -74,6 +85,16 @@ def _safe_endpoint(value: Any) -> str | None:
     netloc = host if port in {None, default} else f"{host}:{port}"
     path = parsed.path or "/"
     return urlunsplit((parsed.scheme.lower(), netloc, path, "", ""))
+
+
+def _provider_origin(provider: Any) -> str | None:
+    endpoint = getattr(provider, "endpoint", None)
+    if not isinstance(endpoint, str) or not endpoint.strip():
+        return None
+    try:
+        return normalize_origin(endpoint.strip())
+    except (PolicyError, ValueError):
+        return None
 
 
 def _provider_name(provider: Any) -> str:
@@ -176,17 +197,96 @@ def _session_ready(provider: Any) -> bool:
 class CognitionProviderAwareness:
     """Fresh privacy-safe awareness over already-bound hosted cognition providers.
 
-    The surface never scans for providers, reads credential values, invokes a
-    callback/network endpoint, changes a binding, or performs provider selection.
-    LocalModelRuntime-backed cognition remains owned by local runtime awareness.
+    Passive inventory never scans for providers, reads credential values, invokes
+    callbacks/network endpoints, changes bindings, or performs provider selection.
+    A separate explicitly authorized refresh may observe only current transport
+    reachability for an already-bound remote origin through the existing A5 Tool
+    Gateway. Transport evidence never establishes provider readiness or fitness.
     """
 
     schema = "grox-live-hosted-cognition-inventory-v1"
     resource_kind = "hosted_cognition_provider"
 
-    def __init__(self, *, reasoner: Any = None, crew_provider: Any = None):
+    def __init__(
+        self,
+        *,
+        reasoner: Any = None,
+        crew_provider: Any = None,
+        gateway: ToolGateway | None = None,
+        transport_observations: MutableMapping[str, Any] | None = None,
+        clock: Callable[[], float] = monotonic,
+        transport_freshness_seconds: float = 60.0,
+    ):
+        if gateway is not None and not isinstance(gateway, ToolGateway):
+            raise TypeError("gateway must be a ToolGateway or null")
+        if not callable(clock):
+            raise TypeError("clock must be callable")
+        if isinstance(transport_freshness_seconds, bool) or not isinstance(
+            transport_freshness_seconds, (int, float)
+        ):
+            raise TypeError("transport_freshness_seconds must be numeric")
+        if transport_freshness_seconds <= 0:
+            raise ValueError("transport_freshness_seconds must be positive")
         self.reasoner = reasoner
         self.crew_provider = crew_provider
+        self.gateway = gateway
+        self.transport_observations = transport_observations if transport_observations is not None else {}
+        self.clock = clock
+        self.transport_freshness_seconds = float(transport_freshness_seconds)
+
+    def _candidates(self) -> tuple[tuple[str, Any], ...]:
+        return (
+            ("gorxu_reasoner", self.reasoner),
+            ("crew_cognition", self.crew_provider),
+        )
+
+    def _transport_snapshot(self, *, resource_id: str, is_remote: bool) -> dict[str, Any]:
+        if not is_remote:
+            return {
+                "transport_reachable": False,
+                "transport_fresh": False,
+                "transport_status": "not_applicable",
+                "transport_http_status": None,
+                "transport_age_seconds": None,
+            }
+        raw = self.transport_observations.get(resource_id)
+        if not isinstance(raw, dict):
+            return {
+                "transport_reachable": False,
+                "transport_fresh": False,
+                "transport_status": "unproven",
+                "transport_http_status": None,
+                "transport_age_seconds": None,
+            }
+        observed_at = raw.get("observed_at")
+        if isinstance(observed_at, bool) or not isinstance(observed_at, (int, float)):
+            return {
+                "transport_reachable": False,
+                "transport_fresh": False,
+                "transport_status": "unproven",
+                "transport_http_status": None,
+                "transport_age_seconds": None,
+            }
+        age = max(0.0, float(self.clock()) - float(observed_at))
+        if age > self.transport_freshness_seconds:
+            return {
+                "transport_reachable": False,
+                "transport_fresh": False,
+                "transport_status": "stale",
+                "transport_http_status": None,
+                "transport_age_seconds": age,
+            }
+        reachable = raw.get("reachable") is True
+        http_status = raw.get("http_status")
+        if isinstance(http_status, bool) or not isinstance(http_status, int):
+            http_status = None
+        return {
+            "transport_reachable": reachable,
+            "transport_fresh": True,
+            "transport_status": "reachable" if reachable else "unreachable",
+            "transport_http_status": http_status if reachable else None,
+            "transport_age_seconds": age,
+        }
 
     def _snapshot(
         self,
@@ -206,8 +306,9 @@ class CognitionProviderAwareness:
         qualification_recorded = resource_id in policy.qualified_ids if policy is not None else False
         observed_identity = _usage_identity(provider)
         observed = observed_identity is not None or _response_observed(provider)
-        is_session = isinstance(provider, (SessionReasoningProvider, SessionCrewCognitionProvider))
-        is_remote = isinstance(provider, (OpenAIResponsesProvider, OpenAICrewCognitionProvider))
+        is_session = isinstance(provider, _SESSION_TYPES)
+        is_remote = isinstance(provider, _REMOTE_TYPES)
+        transport_evidence = self._transport_snapshot(resource_id=resource_id, is_remote=is_remote)
 
         if is_session:
             ready = _session_ready(provider)
@@ -221,11 +322,16 @@ class CognitionProviderAwareness:
         elif is_remote:
             ready = False
             readiness_status = "remote_reachability_unproven"
-            readiness_reason = (
-                "prior provider execution was observed, but current reachability and credential validity were not revalidated"
-                if observed
-                else "remote provider is configured but reachability and credential validity were not probed"
-            )
+            if transport_evidence["transport_fresh"]:
+                readiness_reason = (
+                    "current origin transport was observed separately, but credential, provider, and model readiness remain unproven"
+                )
+            elif observed:
+                readiness_reason = (
+                    "prior provider execution was observed, but current provider readiness and credential validity were not revalidated"
+                )
+            else:
+                readiness_reason = "remote provider is configured but provider readiness and credential validity were not probed"
             transport = "remote_https"
         else:  # pragma: no cover - _HOSTED_TYPES keeps this bounded.
             return None
@@ -259,22 +365,103 @@ class CognitionProviderAwareness:
             "selection_source": "existing_pilot_binding",
             "observed": observed,
             "observed_identity": dict(observed_identity) if observed_identity is not None else None,
+            **transport_evidence,
             "details": details,
             "authority_changed": False,
             "auto_selection": False,
             "auto_invocation": False,
         }
 
+    def _remote_binding(self, resource_id: str) -> tuple[Any, str]:
+        if not isinstance(resource_id, str) or not resource_id.strip():
+            raise CognitionTransportAuthorizationError("resource_id must identify one currently bound remote cognition resource")
+        for role, provider in self._candidates():
+            if provider is None or not isinstance(provider, _REMOTE_TYPES):
+                continue
+            runtime = getattr(provider, "runtime", None)
+            if isinstance(runtime, LocalModelRuntime):
+                continue
+            current_id = _resource_id(role=role, provider=provider)
+            if current_id != resource_id:
+                continue
+            origin = _provider_origin(provider)
+            if origin is None:
+                raise CognitionTransportAuthorizationError("bound remote cognition endpoint has no safe HTTP(S) origin")
+            return provider, origin
+        raise CognitionTransportAuthorizationError("resource_id is not a currently bound remote cognition resource")
+
+    def _authorize_transport_refresh(self, *, resource_id: str, order: MissionOrder, origin: str) -> None:
+        if not isinstance(order, MissionOrder):
+            raise CognitionTransportAuthorizationError("transport refresh requires a MissionOrder")
+        if not order.sealed:
+            raise CognitionTransportAuthorizationError("transport refresh requires an already sealed Mission Order")
+        if "net_fetch" in order.forbidden_actions or "net_fetch" not in order.allowed_actions:
+            raise CognitionTransportAuthorizationError("sealed Mission Order does not grant net_fetch")
+        if order.parameters.get("operation") != "cognition_transport_probe":
+            raise CognitionTransportAuthorizationError("sealed Mission Order operation must be cognition_transport_probe")
+        if order.parameters.get("resource_id") != resource_id:
+            raise CognitionTransportAuthorizationError("sealed Mission Order does not bind this cognition resource_id")
+
+        raw_origins = order.parameters.get("allowed_origins") or ()
+        if not isinstance(raw_origins, (list, tuple)) or not all(
+            isinstance(value, str) and bool(value.strip()) for value in raw_origins
+        ):
+            raise CognitionTransportAuthorizationError("sealed Mission Order allowed_origins are invalid")
+        try:
+            order_origins = frozenset(normalize_origin(value) for value in raw_origins)
+        except PolicyError as exc:
+            raise CognitionTransportAuthorizationError(str(exc)) from exc
+        if origin not in order_origins:
+            raise CognitionTransportAuthorizationError("bound cognition origin is not granted by the sealed Mission Order")
+
+        if self.gateway is None:
+            raise CognitionTransportAuthorizationError("no governed Tool Gateway is bound for transport refresh")
+        if not self.gateway.policy.network_enabled:
+            raise CognitionTransportAuthorizationError("network capability is disabled by host policy")
+        if origin not in self.gateway.policy.allowed_origins:
+            raise CognitionTransportAuthorizationError("bound cognition origin is outside host Gateway policy")
+
+    def refresh_transport(self, *, resource_id: str, order: MissionOrder) -> dict[str, Any]:
+        """Refresh only volatile origin-transport evidence for one bound remote resource.
+
+        This method never seals an Order, sends provider credentials/cognition
+        payloads, persists evidence, changes provider bindings, or asserts remote
+        provider readiness. Runtime network work is delegated exclusively to the
+        existing Tool Gateway after exact authority is prevalidated.
+        """
+        _, origin = self._remote_binding(resource_id)
+        self._authorize_transport_refresh(resource_id=resource_id, order=order, origin=origin)
+        assert self.gateway is not None  # established by authorization above
+
+        observed_at = float(self.clock())
+        try:
+            response = self.gateway.fetch_url(order, origin + "/")
+        except (ToolDenied, TimeoutError, OSError):
+            self.transport_observations[resource_id] = {
+                "observed_at": observed_at,
+                "reachable": False,
+                "http_status": None,
+            }
+        else:
+            status = response.get("status") if isinstance(response, dict) else None
+            self.transport_observations[resource_id] = {
+                "observed_at": observed_at,
+                "reachable": True,
+                "http_status": status if isinstance(status, int) and not isinstance(status, bool) else None,
+            }
+
+        refreshed = self.inventory()["resources"]
+        for item in refreshed:
+            if item["resource_id"] == resource_id:
+                return item
+        raise CognitionTransportAuthorizationError("bound cognition resource changed during transport refresh")
+
     def inventory(self, *, policy: CognitionProviderPolicy | None = None) -> dict[str, Any]:
         if policy is not None and not isinstance(policy, CognitionProviderPolicy):
             raise TypeError("policy must be a CognitionProviderPolicy or null")
         resources: list[dict[str, Any]] = []
         delegated_local = 0
-        candidates = (
-            ("gorxu_reasoner", self.reasoner),
-            ("crew_cognition", self.crew_provider),
-        )
-        for role, provider in candidates:
+        for role, provider in self._candidates():
             if provider is not None and isinstance(getattr(provider, "runtime", None), LocalModelRuntime):
                 delegated_local += 1
                 continue

--- a/src/grox/pilot.py
+++ b/src/grox/pilot.py
@@ -49,6 +49,7 @@ class PilotGorXu:
             secret_broker=secret_broker, mcp_registry=mcp_registry,
         )
         self._tool_awareness=ToolCapabilityAwareness(self.gateway)
+        self._cognition_transport_observations:dict[str,Any]={}
         self.executor=CrewExecutor(self.gateway,self.durable)
         self.verifier=IndependentVerifier()
         self.intelligence=LivingCompanyIntelligence(self.store,self.roster)
@@ -99,12 +100,22 @@ class PilotGorXu:
         """Return fresh governed A5 capability state without invoking tools."""
         return self._tool_awareness.inventory(order=order)
 
-    def live_cognition_provider_inventory(self, *, policy:CognitionProviderPolicy|None=None)->dict[str,Any]:
-        """Return fresh hosted cognition binding state without invoking providers."""
+    def _cognition_provider_awareness(self)->CognitionProviderAwareness:
         crew_provider=getattr(self.executor,'cognition_provider',None)
         return CognitionProviderAwareness(
-            reasoner=self.reasoner, crew_provider=crew_provider
-        ).inventory(policy=policy)
+            reasoner=self.reasoner,
+            crew_provider=crew_provider,
+            gateway=self.gateway,
+            transport_observations=self._cognition_transport_observations,
+        )
+
+    def live_cognition_provider_inventory(self, *, policy:CognitionProviderPolicy|None=None)->dict[str,Any]:
+        """Return fresh hosted cognition binding state without invoking providers."""
+        return self._cognition_provider_awareness().inventory(policy=policy)
+
+    def refresh_cognition_transport(self, *, resource_id:str, order:MissionOrder)->dict[str,Any]:
+        """Refresh bounded remote-origin transport evidence through the governed Tool Gateway."""
+        return self._cognition_provider_awareness().refresh_transport(resource_id=resource_id,order=order)
 
     def _required_caps(self, mode:MissionMode)->list[str]:
         return {'inspect':['repo_read'],'repair':['repo_read','repo_write'],'verify':['repo_read','verify'],'execute':['repo_read']}[mode.value]

--- a/tests/integration/test_cognition_transport_freshness.py
+++ b/tests/integration/test_cognition_transport_freshness.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from grox.contracts import MissionMode, MissionOrder
+from grox.pilot import PilotGorXu
+from grox.reasoning.openai_responses import OpenAIResponsesProvider
+from grox.tools.policy import GatewayPolicy
+from tests._support import temp_vessel
+
+
+ORIGIN = "https://api.openai.com"
+
+
+class PilotCognitionTransportFreshnessTests(unittest.TestCase):
+    def test_pilot_refresh_is_explicit_non_mission_transport_observation_only(self):
+        td, root, bootstrap = temp_vessel()
+        try:
+            bootstrap.store.close()
+            provider = OpenAIResponsesProvider(api_key="pilot-secret-sentinel", model="pilot-remote-model")
+            pilot = PilotGorXu(
+                root,
+                reasoner=provider,
+                gateway_policy=GatewayPolicy(
+                    network_enabled=True,
+                    allowed_origins=frozenset({ORIGIN}),
+                    network_timeout_seconds=3,
+                    max_response_bytes=4096,
+                ),
+            )
+            try:
+                before = pilot.store.recent_missions()
+                resource_id = pilot.live_cognition_provider_inventory()["resources"][0]["resource_id"]
+                order = MissionOrder.new(
+                    "MSN-external-probe-context",
+                    "Refresh only remote transport evidence",
+                    "Probe exact bound cognition origin",
+                    MissionMode.inspect,
+                    "researcher",
+                    allowed_actions=["net_fetch"],
+                    parameters={
+                        "operation": "cognition_transport_probe",
+                        "resource_id": resource_id,
+                        "allowed_origins": [ORIGIN],
+                    },
+                ).seal()
+                with patch.object(
+                    pilot.gateway,
+                    "fetch_url",
+                    return_value={"origin": ORIGIN, "status": 401, "preview": "must-not-escape"},
+                ) as fetch:
+                    refreshed = pilot.refresh_cognition_transport(resource_id=resource_id, order=order)
+                fetch.assert_called_once()
+                self.assertTrue(refreshed["transport_reachable"])
+                self.assertFalse(refreshed["ready"])
+                self.assertFalse(refreshed["authorized"])
+                self.assertEqual(pilot.store.recent_missions(), before)
+
+                current = pilot.live_cognition_provider_inventory()["resources"][0]
+                self.assertTrue(current["transport_reachable"])
+                self.assertFalse(current["ready"])
+                self.assertFalse(current["qualified_fit"])
+                self.assertFalse(current["authority_changed"])
+            finally:
+                pilot.store.close()
+        finally:
+            td.cleanup()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/mutation/run_critical_invariants.py
+++ b/tests/mutation/run_critical_invariants.py
@@ -160,6 +160,14 @@ SPECS: tuple[MutationSpec, ...] = (
         nodeid="tests/unit/test_cognition_provider_awareness.py::CognitionProviderAwarenessTests::test_bound_session_provider_is_discovered_selected_but_not_authorized_or_observed",
     ),
     MutationSpec(
+        name="cognition-transport-presealed-authority",
+        invariant="Remote cognition transport awareness must never acquire authority by allowing the Tool Gateway to seal an unsealed Mission Order.",
+        path="src/grox/cognition_awareness.py",
+        old='        if not order.sealed:\n            raise CognitionTransportAuthorizationError("transport refresh requires an already sealed Mission Order")\n',
+        new='        if False and not order.sealed:\n            raise CognitionTransportAuthorizationError("transport refresh requires an already sealed Mission Order")\n',
+        nodeid="tests/unit/test_cognition_transport_freshness.py::CognitionTransportFreshnessTests::test_unsealed_order_is_rejected_without_becoming_sealed",
+    ),
+    MutationSpec(
         name="ci-action-immutable-pin",
         invariant="Third-party GitHub Actions must remain pinned to immutable full commit SHAs.",
         path=".github/workflows/ci.yml",

--- a/tests/unit/test_cognition_transport_freshness.py
+++ b/tests/unit/test_cognition_transport_freshness.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from grox.cognition_awareness import (
+    CognitionProviderAwareness,
+    CognitionTransportAuthorizationError,
+)
+from grox.contracts import MissionMode, MissionOrder
+from grox.reasoning.openai_responses import OpenAIResponsesProvider
+from grox.tools.gateway import ToolDenied, ToolGateway
+from grox.tools.policy import GatewayPolicy
+
+
+ORIGIN = "https://api.openai.com"
+
+
+class CognitionTransportFreshnessTests(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.root = Path(self.td.name)
+        self.gateway = ToolGateway(
+            self.root,
+            policy=GatewayPolicy(
+                network_enabled=True,
+                allowed_origins=frozenset({ORIGIN}),
+                network_timeout_seconds=3,
+                max_response_bytes=4096,
+            ),
+        )
+        self.provider = OpenAIResponsesProvider(
+            api_key="REMOTE-SECRET-SENTINEL",
+            model="remote-model-sentinel",
+        )
+        self.observations: dict[str, object] = {}
+        self.now = 1000.0
+        self.awareness = CognitionProviderAwareness(
+            reasoner=self.provider,
+            gateway=self.gateway,
+            transport_observations=self.observations,
+            clock=lambda: self.now,
+            transport_freshness_seconds=60,
+        )
+        self.resource_id = self.awareness.inventory()["resources"][0]["resource_id"]
+
+    def tearDown(self):
+        self.td.cleanup()
+
+    def order(
+        self,
+        *,
+        allowed_actions=("net_fetch",),
+        allowed_origins=(ORIGIN,),
+        resource_id: str | None = None,
+        operation: str = "cognition_transport_probe",
+        seal: bool = True,
+    ) -> MissionOrder:
+        order = MissionOrder.new(
+            "MSN-transport-test",
+            "Refresh remote cognition transport evidence",
+            "Refresh only the exact bound remote cognition origin",
+            MissionMode.inspect,
+            "researcher",
+            allowed_actions=allowed_actions,
+            parameters={
+                "operation": operation,
+                "resource_id": resource_id or self.resource_id,
+                "allowed_origins": list(allowed_origins),
+            },
+        )
+        return order.seal() if seal else order
+
+    def test_passive_inventory_performs_zero_network_io(self):
+        with patch.object(self.gateway, "fetch_url") as fetch:
+            inventory = self.awareness.inventory()
+        fetch.assert_not_called()
+        item = inventory["resources"][0]
+        self.assertFalse(item["ready"])
+        self.assertFalse(item["transport_reachable"])
+        self.assertFalse(item["transport_fresh"])
+        self.assertEqual(item["transport_status"], "unproven")
+
+    def test_unsealed_order_is_rejected_without_becoming_sealed(self):
+        order = self.order(seal=False)
+        with patch.object(self.gateway, "fetch_url") as fetch:
+            with self.assertRaises(CognitionTransportAuthorizationError):
+                self.awareness.refresh_transport(resource_id=self.resource_id, order=order)
+        fetch.assert_not_called()
+        self.assertFalse(order.sealed)
+
+    def test_exact_net_fetch_operation_resource_and_origin_grants_are_required(self):
+        cases = [
+            self.order(allowed_actions=()),
+            self.order(allowed_origins=("https://example.invalid",)),
+            self.order(resource_id="cognition:gorxu_reasoner:other:000000000000"),
+            self.order(operation="http_fetch"),
+        ]
+        for order in cases:
+            with self.subTest(parameters=dict(order.parameters)):
+                with patch.object(self.gateway, "fetch_url") as fetch:
+                    with self.assertRaises(CognitionTransportAuthorizationError):
+                        self.awareness.refresh_transport(resource_id=self.resource_id, order=order)
+                fetch.assert_not_called()
+
+    def test_positive_http_observation_is_privacy_minimized_and_never_implies_ready(self):
+        response = {
+            "url": ORIGIN + "/",
+            "origin": ORIGIN,
+            "status": 401,
+            "content_type": "application/json",
+            "bytes": 321,
+            "sha256": "a" * 64,
+            "redirect_followed": False,
+            "preview": "RESPONSE-BODY-SENTINEL",
+        }
+        with patch.object(self.gateway, "fetch_url", return_value=response) as fetch:
+            refreshed = self.awareness.refresh_transport(
+                resource_id=self.resource_id,
+                order=self.order(),
+            )
+        fetch.assert_called_once()
+        _, url = fetch.call_args.args
+        self.assertEqual(url, ORIGIN + "/")
+        encoded_call = repr(fetch.call_args)
+        self.assertNotIn("REMOTE-SECRET-SENTINEL", encoded_call)
+        self.assertNotIn("remote-model-sentinel", encoded_call)
+
+        self.assertTrue(refreshed["transport_reachable"])
+        self.assertTrue(refreshed["transport_fresh"])
+        self.assertEqual(refreshed["transport_status"], "reachable")
+        self.assertEqual(refreshed["transport_http_status"], 401)
+        self.assertFalse(refreshed["ready"])
+        self.assertFalse(refreshed["authorized"])
+        self.assertFalse(refreshed["qualified_fit"])
+
+        encoded = json.dumps(refreshed, sort_keys=True)
+        self.assertNotIn("RESPONSE-BODY-SENTINEL", encoded)
+        self.assertNotIn("REMOTE-SECRET-SENTINEL", encoded)
+
+    def test_transport_observation_expires_without_becoming_remote_readiness(self):
+        with patch.object(
+            self.gateway,
+            "fetch_url",
+            return_value={"origin": ORIGIN, "status": 404, "preview": "ignored"},
+        ):
+            self.awareness.refresh_transport(resource_id=self.resource_id, order=self.order())
+        self.now += 61
+        item = self.awareness.inventory()["resources"][0]
+        self.assertFalse(item["transport_reachable"])
+        self.assertFalse(item["transport_fresh"])
+        self.assertEqual(item["transport_status"], "stale")
+        self.assertFalse(item["ready"])
+
+    def test_network_failure_replaces_prior_positive_current_claim(self):
+        with patch.object(
+            self.gateway,
+            "fetch_url",
+            return_value={"origin": ORIGIN, "status": 200, "preview": "ignored"},
+        ):
+            first = self.awareness.refresh_transport(resource_id=self.resource_id, order=self.order())
+        self.assertTrue(first["transport_reachable"])
+
+        self.now += 1
+        with patch.object(self.gateway, "fetch_url", side_effect=ToolDenied("network request failed")):
+            second = self.awareness.refresh_transport(resource_id=self.resource_id, order=self.order())
+        self.assertFalse(second["transport_reachable"])
+        self.assertTrue(second["transport_fresh"])
+        self.assertEqual(second["transport_status"], "unreachable")
+        self.assertIsNone(second["transport_http_status"])
+        self.assertFalse(second["ready"])
+
+    def test_rebinding_ignores_prior_resource_transport_observation(self):
+        with patch.object(
+            self.gateway,
+            "fetch_url",
+            return_value={"origin": ORIGIN, "status": 200, "preview": "ignored"},
+        ):
+            self.awareness.refresh_transport(resource_id=self.resource_id, order=self.order())
+
+        rebound = OpenAIResponsesProvider(api_key="different-secret", model="different-model")
+        rebound_awareness = CognitionProviderAwareness(
+            reasoner=rebound,
+            gateway=self.gateway,
+            transport_observations=self.observations,
+            clock=lambda: self.now,
+            transport_freshness_seconds=60,
+        )
+        item = rebound_awareness.inventory()["resources"][0]
+        self.assertNotEqual(item["resource_id"], self.resource_id)
+        self.assertFalse(item["transport_reachable"])
+        self.assertFalse(item["transport_fresh"])
+        self.assertEqual(item["transport_status"], "unproven")
+
+    def test_non_remote_bound_resource_cannot_be_transport_probed(self):
+        from grox.reasoning.session import SessionReasoningProvider
+
+        session_awareness = CognitionProviderAwareness(
+            reasoner=SessionReasoningProvider(lambda directive, roster: {}, name="session-only"),
+            gateway=self.gateway,
+            transport_observations=self.observations,
+            clock=lambda: self.now,
+        )
+        resource_id = session_awareness.inventory()["resources"][0]["resource_id"]
+        order = self.order(resource_id=resource_id)
+        with patch.object(self.gateway, "fetch_url") as fetch:
+            with self.assertRaises(CognitionTransportAuthorizationError):
+                session_awareness.refresh_transport(resource_id=resource_id, order=order)
+        fetch.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements child issue #128 under parent #115.

## Bounded surface

This PR adds **governed remote cognition transport freshness** for already-bound remote cognition resources only.

- passive hosted cognition inventory remains zero-network and non-invoking;
- active refresh is explicit and requires an **already sealed** Mission Order; awareness never seals an Order itself;
- exact `net_fetch`, `operation=cognition_transport_probe`, exact current `resource_id`, and exact origin grants are required;
- origin must be allowed by both the sealed Mission Order and existing host Tool Gateway policy;
- probing reuses the existing A5 `ToolGateway.fetch_url(...)` path — no parallel HTTP/network client;
- request is a bounded unauthenticated GET to the normalized bound origin root and carries no provider credential, prompt/model request, Commander content, Crew context, or secret;
- awareness retains only volatile current-session transport evidence: timestamp, reachable/unreachable state, and bounded HTTP status; response body/preview is discarded;
- a fresh HTTP observation proves only **origin transport reachability** and never sets remote `ready`, `authorized`, or `qualified_fit`;
- freshness expires; network failure replaces any prior positive current claim; provider rebinding changes the resource identity so prior transport evidence does not carry forward;
- session/local resources cannot use the remote transport probe;
- Pilot GorXu exposes the refresh without creating a Mission, switching providers, invoking cognition, or changing routing.

## Permanent authority proof

Adds critical mutation `cognition-transport-presealed-authority`: weakening awareness so an unsealed Order can reach the Tool Gateway must make the targeted regression red, then restore green exactly. Final critical matrix is **16/16 killed**.

## Evidence

Red-before-green:
- tests-only head `b40f7ebfa31d2687ff15a03219733b4f6c18023c` produced GroX CI #423 / `32664409931` red at pytest collection with the expected missing transport-awareness contract while Wheel/bootstrap and earlier source-health setup remained green.

Final exact candidate:
- head `ba69209e1a92b48561903d372947bcf2db7c824d`
- GroX CI #426 / `32710787713`: **PASS across Wheel + Python 3.11–3.14**
- CI-tested synthetic merge: `807d4cb70d78ace26349a4fa6412605e89b8dfb8`
- CI-tested synthetic merge tree: `9cc6ed2765cfc226e279ae498ebabd6ade675bd5`

Python 3.12:
- Vessel Health: **10 PASS / 0 WARN / 0 FAIL / 0 UNKNOWN**
- pytest: **373 passed, 2 skipped, 453 subtests**
- unittest: **375 tests, 2 skipped**
- critical mutations: **16/16**
- health mutations: **7/7**
- reconstitution mutations: **9/9**
- operational drift mutations: **4/4**
- source provenance mutations: **6/6**
- Post-Apex integrated operational qualification: **PASS**

Exact five-file scope:
1. `src/grox/cognition_awareness.py`
2. `src/grox/pilot.py`
3. `tests/integration/test_cognition_transport_freshness.py`
4. `tests/mutation/run_critical_invariants.py`
5. `tests/unit/test_cognition_transport_freshness.py`

## Non-goals / unchanged boundaries

No provider/catalog discovery; no credential validation; no provider/model readiness claim; no provider switching or fallback; no adaptive routing; no Tool Gateway bypass or authority widening; no persistent transport claim; no Repair/verifier/Standing Crew/command-layer change; no release/package change; no NCI advancement; no Apex stage; no A8.

This PR qualifies only issue #128's bounded transport-freshness exit if the remaining exact-head review, guarded merge, and exact-tree proof pass. Parent #115 remains broader and **OPEN**.