### PR TITLE
Repair transport evidence binding across remote endpoint rebinds

### DIFF
--- a/src/grox/cognition_awareness.py
+++ b/src/grox/cognition_awareness.py
@@ -271,6 +271,14 @@ class CognitionProviderAwareness:
                 observed_origin = normalize_origin(observed_origin_raw)
             except (PolicyError, ValueError):
                 observed_origin = None
+        if observed_origin is None or current_origin is None:
+            return {
+                "transport_reachable": False,
+                "transport_fresh": False,
+                "transport_status": "unproven",
+                "transport_http_status": None,
+                "transport_age_seconds": None,
+            }
         if observed_origin != current_origin:
             return {
                 "transport_reachable": False,

--- a/src/grox/cognition_awareness.py
+++ b/src/grox/cognition_awareness.py
@@ -240,7 +240,13 @@ class CognitionProviderAwareness:
             ("crew_cognition", self.crew_provider),
         )
 
-    def _transport_snapshot(self, *, resource_id: str, is_remote: bool) -> dict[str, Any]:
+    def _transport_snapshot(
+        self,
+        *,
+        resource_id: str,
+        is_remote: bool,
+        current_origin: str | None,
+    ) -> dict[str, Any]:
         if not is_remote:
             return {
                 "transport_reachable": False,
@@ -251,6 +257,21 @@ class CognitionProviderAwareness:
             }
         raw = self.transport_observations.get(resource_id)
         if not isinstance(raw, dict):
+            return {
+                "transport_reachable": False,
+                "transport_fresh": False,
+                "transport_status": "unproven",
+                "transport_http_status": None,
+                "transport_age_seconds": None,
+            }
+        observed_origin_raw = raw.get("origin")
+        observed_origin = None
+        if isinstance(observed_origin_raw, str) and observed_origin_raw.strip():
+            try:
+                observed_origin = normalize_origin(observed_origin_raw)
+            except (PolicyError, ValueError):
+                observed_origin = None
+        if observed_origin != current_origin:
             return {
                 "transport_reachable": False,
                 "transport_fresh": False,
@@ -308,7 +329,12 @@ class CognitionProviderAwareness:
         observed = observed_identity is not None or _response_observed(provider)
         is_session = isinstance(provider, _SESSION_TYPES)
         is_remote = isinstance(provider, _REMOTE_TYPES)
-        transport_evidence = self._transport_snapshot(resource_id=resource_id, is_remote=is_remote)
+        current_origin = _provider_origin(provider) if is_remote else None
+        transport_evidence = self._transport_snapshot(
+            resource_id=resource_id,
+            is_remote=is_remote,
+            current_origin=current_origin,
+        )
 
         if is_session:
             ready = _session_ready(provider)
@@ -439,6 +465,7 @@ class CognitionProviderAwareness:
         except (ToolDenied, TimeoutError, OSError):
             self.transport_observations[resource_id] = {
                 "observed_at": observed_at,
+                "origin": origin,
                 "reachable": False,
                 "http_status": None,
             }
@@ -446,6 +473,7 @@ class CognitionProviderAwareness:
             status = response.get("status") if isinstance(response, dict) else None
             self.transport_observations[resource_id] = {
                 "observed_at": observed_at,
+                "origin": origin,
                 "reachable": True,
                 "http_status": status if isinstance(status, int) and not isinstance(status, bool) else None,
             }

--- a/tests/mutation/run_critical_invariants.py
+++ b/tests/mutation/run_critical_invariants.py
@@ -168,6 +168,14 @@ SPECS: tuple[MutationSpec, ...] = (
         nodeid="tests/unit/test_cognition_transport_freshness.py::CognitionTransportFreshnessTests::test_unsealed_order_is_rejected_without_becoming_sealed",
     ),
     MutationSpec(
+        name="cognition-transport-origin-binding",
+        invariant="Remote cognition transport evidence must remain bound to the exact currently configured origin.",
+        path="src/grox/cognition_awareness.py",
+        old="        if observed_origin != current_origin:\n",
+        new="        if False and observed_origin != current_origin:\n",
+        nodeid="tests/unit/test_cognition_transport_freshness.py::CognitionTransportFreshnessTests::test_same_resource_identity_endpoint_rebind_invalidates_prior_origin_evidence",
+    ),
+    MutationSpec(
         name="ci-action-immutable-pin",
         invariant="Third-party GitHub Actions must remain pinned to immutable full commit SHAs.",
         path=".github/workflows/ci.yml",

--- a/tests/unit/test_cognition_transport_freshness.py
+++ b/tests/unit/test_cognition_transport_freshness.py
@@ -222,6 +222,21 @@ class CognitionTransportFreshnessTests(unittest.TestCase):
         self.assertFalse(item["transport_fresh"])
         self.assertEqual(item["transport_status"], "unproven")
 
+    def test_missing_or_malformed_observation_origin_fails_closed(self):
+        for observed_origin in (None, "not-an-http-origin"):
+            with self.subTest(observed_origin=observed_origin):
+                self.observations[self.resource_id] = {
+                    "observed_at": self.now,
+                    "origin": observed_origin,
+                    "reachable": True,
+                    "http_status": 200,
+                }
+                item = self.awareness.inventory()["resources"][0]
+                self.assertFalse(item["transport_reachable"])
+                self.assertFalse(item["transport_fresh"])
+                self.assertEqual(item["transport_status"], "unproven")
+                self.assertIsNone(item["transport_http_status"])
+
     def test_non_remote_bound_resource_cannot_be_transport_probed(self):
         from grox.reasoning.session import SessionReasoningProvider
 

--- a/tests/unit/test_cognition_transport_freshness.py
+++ b/tests/unit/test_cognition_transport_freshness.py
@@ -195,6 +195,33 @@ class CognitionTransportFreshnessTests(unittest.TestCase):
         self.assertFalse(item["transport_fresh"])
         self.assertEqual(item["transport_status"], "unproven")
 
+    def test_same_resource_identity_endpoint_rebind_invalidates_prior_origin_evidence(self):
+        with patch.object(
+            self.gateway,
+            "fetch_url",
+            return_value={"origin": ORIGIN, "status": 200, "preview": "ignored"},
+        ):
+            first = self.awareness.refresh_transport(resource_id=self.resource_id, order=self.order())
+        self.assertTrue(first["transport_reachable"])
+
+        rebound = OpenAIResponsesProvider(
+            api_key="different-secret",
+            model="remote-model-sentinel",
+            endpoint="https://example.invalid/v1/responses",
+        )
+        rebound_awareness = CognitionProviderAwareness(
+            reasoner=rebound,
+            gateway=self.gateway,
+            transport_observations=self.observations,
+            clock=lambda: self.now,
+            transport_freshness_seconds=60,
+        )
+        item = rebound_awareness.inventory()["resources"][0]
+        self.assertEqual(item["resource_id"], self.resource_id)
+        self.assertFalse(item["transport_reachable"])
+        self.assertFalse(item["transport_fresh"])
+        self.assertEqual(item["transport_status"], "unproven")
+
     def test_non_remote_bound_resource_cannot_be_transport_probed(self):
         from grox.reasoning.session import SessionReasoningProvider
 

--- a/tests/unit/test_cognition_transport_freshness.py
+++ b/tests/unit/test_cognition_transport_freshness.py
@@ -237,6 +237,32 @@ class CognitionTransportFreshnessTests(unittest.TestCase):
                 self.assertEqual(item["transport_status"], "unproven")
                 self.assertIsNone(item["transport_http_status"])
 
+    def test_invalid_current_origin_cannot_match_missing_observation_origin(self):
+        self.observations[self.resource_id] = {
+            "observed_at": self.now,
+            "origin": None,
+            "reachable": True,
+            "http_status": 200,
+        }
+        rebound = OpenAIResponsesProvider(
+            api_key="different-secret",
+            model="remote-model-sentinel",
+            endpoint="not-an-http-origin",
+        )
+        rebound_awareness = CognitionProviderAwareness(
+            reasoner=rebound,
+            gateway=self.gateway,
+            transport_observations=self.observations,
+            clock=lambda: self.now,
+            transport_freshness_seconds=60,
+        )
+        item = rebound_awareness.inventory()["resources"][0]
+        self.assertEqual(item["resource_id"], self.resource_id)
+        self.assertFalse(item["transport_reachable"])
+        self.assertFalse(item["transport_fresh"])
+        self.assertEqual(item["transport_status"], "unproven")
+        self.assertIsNone(item["transport_http_status"])
+
     def test_non_remote_bound_resource_cannot_be_transport_probed(self):
         from grox.reasoning.session import SessionReasoningProvider
 


### PR DESCRIPTION
Closes #132 only after exact-head qualification and exact-tree proof. Parent #115 remains OPEN.

## Purpose

Fail-closed repair discovered during post-#131 recalibration. Current transport evidence is keyed by cognition resource identity, but that identity does not include endpoint/origin. A same-provider/same-model endpoint rebind can therefore inherit a still-fresh transport observation from the prior origin.

## Required behavior

- bind each transport observation to the exact normalized origin actually probed;
- compare recorded origin with the resource's current bound origin before claiming freshness/reachability;
- missing/malformed/mismatched origin evidence fails closed;
- same provider/model with a changed endpoint immediately loses the prior current transport claim without network I/O;
- preserve pre-sealed exact `net_fetch` authority and A5 Tool Gateway origin enforcement;
- preserve privacy minimization and `ready=False` for remote providers;
- add a permanent critical mutation detector for the origin-binding gate.

## Red-before-green

The first branch commit intentionally adds only the regression for the canonical defect. Exact PR CI from that commit is expected to fail only the new endpoint-rebind assertion; production repair follows only after that evidence is captured.

No provider readiness, credential validation, routing, selection/fallback, release/package, NCI, Apex, or A8 change is in scope.