### PR TITLE
Qualify official OpenAI authenticated model visibility probe

### DIFF
--- a/src/grox/configured_openai_probe.py
+++ b/src/grox/configured_openai_probe.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .configured_credential_use_authorization import (
+    ConfiguredCredentialUseAuthorization,
+    ConfiguredCredentialUseAuthorizationError,
+)
+from .contracts import MissionOrder
+from .tools.layout_gateway import LayoutToolGateway
+
+
+class ConfiguredOpenAIAuthenticatedModelProbeError(PermissionError):
+    """Configured authenticated OpenAI model probe failed closed."""
+
+
+class ConfiguredOpenAIAuthenticatedModelProbe:
+    """Probe exact configured official OpenAI model visibility under Mission authority.
+
+    Configuration identity is resolved here before the Tool Gateway is allowed to
+    materialize or transmit a credential. The gateway remains the final secret and
+    network boundary. No cognition request, readiness promotion, fitness decision,
+    provider selection, fallback, or authority widening occurs here.
+    """
+
+    operation = "configured_openai_authenticated_model_probe"
+    official_responses_endpoint = "https://api.openai.com/v1/responses"
+
+    def __init__(self, config: Mapping[str, Any], gateway: LayoutToolGateway):
+        if not isinstance(config, Mapping):
+            raise TypeError("config must be a mapping")
+        if not isinstance(gateway, LayoutToolGateway):
+            raise TypeError("gateway must be a LayoutToolGateway")
+        self._config = dict(config)
+        self._gateway = gateway
+        self._authorization = ConfiguredCredentialUseAuthorization(self._config, gateway)
+
+    def probe(self, *, order: MissionOrder) -> dict[str, Any]:
+        if not isinstance(order, MissionOrder):
+            raise TypeError("order must be a MissionOrder")
+        try:
+            authorization = self._authorization.inventory(
+                order=order,
+                expected_operation=self.operation,
+            )
+        except ConfiguredCredentialUseAuthorizationError as exc:
+            raise ConfiguredOpenAIAuthenticatedModelProbeError(
+                "authenticated OpenAI model probe requires an already sealed Mission Order"
+            ) from exc
+
+        resources = authorization.get("resources") or []
+        if authorization.get("status") != "ok" or len(resources) != 1:
+            raise ConfiguredOpenAIAuthenticatedModelProbeError(
+                "authenticated OpenAI model probe is not applicable to current configured cognition"
+            )
+        item = resources[0]
+        if item.get("provider_kind") != "openai":
+            raise ConfiguredOpenAIAuthenticatedModelProbeError(
+                "authenticated OpenAI model probe requires configured provider kind openai"
+            )
+        if item.get("endpoint") != self.official_responses_endpoint:
+            raise ConfiguredOpenAIAuthenticatedModelProbeError(
+                "authenticated OpenAI model probe requires the exact official Responses endpoint"
+            )
+        if item.get("credential_use_authorized") is not True:
+            status = str(authorization.get("authorization_status") or "denied")
+            raise ConfiguredOpenAIAuthenticatedModelProbeError(
+                f"authenticated OpenAI model probe denied: {status}"
+            )
+
+        alias = item.get("credential_alias")
+        if not isinstance(alias, str) or not alias:
+            raise ConfiguredOpenAIAuthenticatedModelProbeError(
+                "authenticated OpenAI model probe has no exact credential alias"
+            )
+
+        try:
+            result = self._gateway.openai_model_probe(
+                order,
+                resource_id=str(item["resource_id"]),
+                responses_endpoint=str(item["endpoint"]),
+                model=str(item["model"]),
+                credential_alias=alias,
+            )
+        except (PermissionError, TypeError, ValueError, TimeoutError) as exc:
+            if isinstance(exc, TimeoutError):
+                raise
+            raise ConfiguredOpenAIAuthenticatedModelProbeError(
+                f"authenticated OpenAI model probe denied: {exc}"
+            ) from exc
+
+        return {
+            **result,
+            "resource_id": str(item["resource_id"]),
+            "provider_kind": "openai",
+            "endpoint": self.official_responses_endpoint,
+            "credential_use_authorized": True,
+            "mission_created": False,
+            "observed": result.get("classification") == "authenticated_model_visible",
+            "auto_selection": False,
+        }

--- a/src/grox/configured_openai_probe.py
+++ b/src/grox/configured_openai_probe.py
@@ -21,7 +21,7 @@ class ConfiguredOpenAIAuthenticatedModelProbe:
     Configuration identity is resolved here before the Tool Gateway is allowed to
     materialize or transmit a credential. The gateway remains the final secret and
     network boundary. No cognition request, readiness promotion, fitness decision,
-    provider selection, fallback, or authority widening occurs here.
+    provider selection, fallback, observation promotion, or authority widening occurs.
     """
 
     operation = "configured_openai_authenticated_model_probe"
@@ -97,6 +97,6 @@ class ConfiguredOpenAIAuthenticatedModelProbe:
             "endpoint": self.official_responses_endpoint,
             "credential_use_authorized": True,
             "mission_created": False,
-            "observed": result.get("classification") == "authenticated_model_visible",
+            "observed": False,
             "auto_selection": False,
         }

--- a/src/grox/tools/layout_gateway.py
+++ b/src/grox/tools/layout_gateway.py
@@ -1,11 +1,23 @@
 from __future__ import annotations
 
+import hashlib
+import http.client
+import json
+import ssl
+from urllib.parse import quote
+
 from ..runtime_layout import VesselLayout
 from .browser import BrowserRuntime
 from .gateway import ToolDenied, ToolGateway
 from .policy import GatewayPolicy
-from .secrets import SecretDenied
+from .secrets import SecretBroker, SecretDenied
 from .workspace import IsolatedWorkspace, WorkspaceUnavailable
+
+
+_OFFICIAL_OPENAI_RESPONSES_ENDPOINT = "https://api.openai.com/v1/responses"
+_OFFICIAL_OPENAI_ORIGIN = "https://api.openai.com"
+_OPENAI_PROBE_OPERATION = "configured_openai_authenticated_model_probe"
+_OPENAI_PROBE_SECRET_ENV = "GROX_OPENAI_PROBE_CREDENTIAL"
 
 
 class LayoutToolGateway(ToolGateway):
@@ -73,3 +85,121 @@ class LayoutToolGateway(ToolGateway):
         result["stderr"] = self.secret_broker.redact(result["stderr"], secret_values)
         result["secret_aliases"] = aliases
         return result
+
+    def openai_model_probe(
+        self,
+        order,
+        *,
+        resource_id: str,
+        responses_endpoint: str,
+        model: str,
+        credential_alias: str,
+    ) -> dict:
+        """Perform one credential-bearing official OpenAI model metadata GET.
+
+        This is intentionally not a generic authenticated HTTP surface. The
+        credential may leave the Vessel only for the exact official OpenAI API
+        endpoint and only under a sealed Order that binds the exact configured
+        resource/model/endpoint/alias plus both network and secret authority.
+        Response body text and credential material are never returned.
+        """
+        self._allowed(order, "net_fetch")
+        self._allowed(order, "secret_use")
+        if not self.policy.network_enabled:
+            raise ToolDenied("network access disabled by host policy")
+        if responses_endpoint != _OFFICIAL_OPENAI_RESPONSES_ENDPOINT:
+            raise ToolDenied("authenticated OpenAI probe requires the exact official Responses endpoint")
+        parameters = order.parameters
+        exact = (
+            parameters.get("operation") == _OPENAI_PROBE_OPERATION
+            and parameters.get("resource_id") == resource_id
+            and parameters.get("provider_kind") == "openai"
+            and parameters.get("model") == model
+            and parameters.get("endpoint") == responses_endpoint
+            and parameters.get("credential_alias") == credential_alias
+        )
+        if not exact:
+            raise ToolDenied("authenticated OpenAI probe Mission identity mismatch")
+
+        model_url = f"{_OFFICIAL_OPENAI_ORIGIN}/v1/models/{quote(model, safe='')}"
+        origin, _ = self._assert_url(order, model_url)
+        if origin != _OFFICIAL_OPENAI_ORIGIN:
+            raise ToolDenied("authenticated OpenAI probe origin mismatch")
+
+        try:
+            secret_values, aliases = self.secret_broker.materialize_env(
+                order,
+                {_OPENAI_PROBE_SECRET_ENV: credential_alias},
+            )
+        except SecretDenied as exc:
+            raise ToolDenied("authenticated OpenAI probe credential materialization denied") from exc
+        if aliases != [credential_alias]:
+            secret_values.clear()
+            raise ToolDenied("authenticated OpenAI probe credential identity mismatch")
+        api_key = secret_values.pop(_OPENAI_PROBE_SECRET_ENV, None)
+        secret_values.clear()
+        if not isinstance(api_key, str) or not api_key:
+            raise ToolDenied("authenticated OpenAI probe credential materialization produced no usable value")
+
+        conn = http.client.HTTPSConnection(
+            "api.openai.com",
+            443,
+            timeout=self.policy.network_timeout_seconds,
+            context=ssl.create_default_context(),
+        )
+        try:
+            conn.request(
+                "GET",
+                f"/v1/models/{quote(model, safe='')}",
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "User-Agent": "GroX/1.0",
+                    "Accept": "application/json",
+                },
+            )
+            response = conn.getresponse()
+            raw = response.read(self.policy.max_response_bytes + 1)
+            if len(raw) > self.policy.max_response_bytes:
+                raise ToolDenied(
+                    f"network response exceeds {self.policy.max_response_bytes} bytes"
+                )
+            status = int(response.status)
+            content_type = (response.getheader("Content-Type") or "")[:200]
+            model_identity = None
+            metadata_valid = False
+            if status == 200:
+                try:
+                    payload = json.loads(raw.decode("utf-8"))
+                except (UnicodeDecodeError, json.JSONDecodeError):
+                    payload = None
+                if isinstance(payload, dict):
+                    candidate = payload.get("id")
+                    metadata_valid = (
+                        candidate == model and payload.get("object") == "model"
+                    )
+                    if metadata_valid:
+                        model_identity = candidate
+            return {
+                "url": model_url,
+                "origin": _OFFICIAL_OPENAI_ORIGIN,
+                "status": status,
+                "content_type": content_type,
+                "bytes": len(raw),
+                "sha256": hashlib.sha256(raw).hexdigest(),
+                "requested_model": model,
+                "model_identity": model_identity,
+                "metadata_valid": metadata_valid,
+                "credential_alias": credential_alias,
+                "secret_materialized": True,
+                "network_invoked": True,
+                "response_body_returned": False,
+            }
+        except TimeoutError:
+            raise
+        except OSError as exc:
+            raise ToolDenied(
+                "authenticated OpenAI probe network request failed within exact official origin"
+            ) from exc
+        finally:
+            api_key = None
+            conn.close()

--- a/src/grox/tools/layout_gateway.py
+++ b/src/grox/tools/layout_gateway.py
@@ -10,7 +10,7 @@ from ..runtime_layout import VesselLayout
 from .browser import BrowserRuntime
 from .gateway import ToolDenied, ToolGateway
 from .policy import GatewayPolicy
-from .secrets import SecretBroker, SecretDenied
+from .secrets import SecretDenied
 from .workspace import IsolatedWorkspace, WorkspaceUnavailable
 
 
@@ -150,13 +150,14 @@ class LayoutToolGateway(ToolGateway):
         if not isinstance(api_key, str) or not api_key:
             raise ToolDenied("authenticated OpenAI probe credential materialization produced no usable value")
 
-        conn = http.client.HTTPSConnection(
-            "api.openai.com",
-            443,
-            timeout=self.policy.network_timeout_seconds,
-            context=ssl.create_default_context(),
-        )
+        conn = None
         try:
+            conn = http.client.HTTPSConnection(
+                "api.openai.com",
+                443,
+                timeout=self.policy.network_timeout_seconds,
+                context=ssl.create_default_context(),
+            )
             conn.request(
                 "GET",
                 f"/v1/models/{quote(model, safe='')}",
@@ -221,4 +222,5 @@ class LayoutToolGateway(ToolGateway):
             ) from exc
         finally:
             api_key = None
-            conn.close()
+            if conn is not None:
+                conn.close()

--- a/src/grox/tools/layout_gateway.py
+++ b/src/grox/tools/layout_gateway.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-import hashlib
 import http.client
 import json
 import ssl
 from urllib.parse import quote
 
+from ..contracts import MissionOrder
 from ..runtime_layout import VesselLayout
 from .browser import BrowserRuntime
 from .gateway import ToolDenied, ToolGateway
@@ -88,7 +88,7 @@ class LayoutToolGateway(ToolGateway):
 
     def openai_model_probe(
         self,
-        order,
+        order: MissionOrder,
         *,
         resource_id: str,
         responses_endpoint: str,
@@ -99,16 +99,25 @@ class LayoutToolGateway(ToolGateway):
 
         This is intentionally not a generic authenticated HTTP surface. The
         credential may leave the Vessel only for the exact official OpenAI API
-        endpoint and only under a sealed Order that binds the exact configured
-        resource/model/endpoint/alias plus both network and secret authority.
-        Response body text and credential material are never returned.
+        endpoint and only under an already-sealed Order that binds the exact
+        configured resource/model/endpoint/alias plus both network and secret
+        authority. Response body text and credential material are never returned.
         """
+        if not isinstance(order, MissionOrder):
+            raise TypeError("order must be a MissionOrder")
+        if not order.sealed:
+            raise ToolDenied("authenticated OpenAI probe requires an already sealed Mission Order")
         self._allowed(order, "net_fetch")
         self._allowed(order, "secret_use")
         if not self.policy.network_enabled:
             raise ToolDenied("network access disabled by host policy")
         if responses_endpoint != _OFFICIAL_OPENAI_RESPONSES_ENDPOINT:
             raise ToolDenied("authenticated OpenAI probe requires the exact official Responses endpoint")
+        if not isinstance(model, str) or not model or len(model) > 160:
+            raise ToolDenied("authenticated OpenAI probe requires a bounded model identity")
+        if not isinstance(credential_alias, str) or not credential_alias:
+            raise ToolDenied("authenticated OpenAI probe requires an exact credential alias")
+
         parameters = order.parameters
         exact = (
             parameters.get("operation") == _OPENAI_PROBE_OPERATION
@@ -164,7 +173,6 @@ class LayoutToolGateway(ToolGateway):
                     f"network response exceeds {self.policy.max_response_bytes} bytes"
                 )
             status = int(response.status)
-            content_type = (response.getheader("Content-Type") or "")[:200]
             model_identity = None
             metadata_valid = False
             if status == 200:
@@ -174,25 +182,36 @@ class LayoutToolGateway(ToolGateway):
                     payload = None
                 if isinstance(payload, dict):
                     candidate = payload.get("id")
-                    metadata_valid = (
-                        candidate == model and payload.get("object") == "model"
-                    )
+                    metadata_valid = candidate == model and payload.get("object") == "model"
                     if metadata_valid:
                         model_identity = candidate
+
+            if status == 200 and metadata_valid:
+                classification = "authenticated_model_visible"
+            elif status == 401:
+                classification = "credential_rejected"
+            else:
+                classification = "indeterminate"
+
             return {
-                "url": model_url,
+                "schema": "grox-openai-authenticated-model-probe-v1",
                 "origin": _OFFICIAL_OPENAI_ORIGIN,
                 "status": status,
-                "content_type": content_type,
-                "bytes": len(raw),
-                "sha256": hashlib.sha256(raw).hexdigest(),
+                "classification": classification,
                 "requested_model": model,
                 "model_identity": model_identity,
                 "metadata_valid": metadata_valid,
                 "credential_alias": credential_alias,
+                "credential_accepted_for_model_visibility": classification == "authenticated_model_visible",
+                "credential_rejected": classification == "credential_rejected",
                 "secret_materialized": True,
                 "network_invoked": True,
                 "response_body_returned": False,
+                "cognition_invoked": False,
+                "ready": False,
+                "qualified_fit": False,
+                "selected": False,
+                "authority_changed": False,
             }
         except TimeoutError:
             raise

--- a/tests/integration/test_configured_openai_probe.py
+++ b/tests/integration/test_configured_openai_probe.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from grox.cognition_discovery import (
+    ConfiguredCognitionDiscovery,
+    nonsecret_reasoner_config_from_env,
+)
+from grox.configured_openai_probe import ConfiguredOpenAIAuthenticatedModelProbe
+from grox.contracts import MissionMode, MissionOrder
+from grox.runtime_layout import VesselLayout
+from grox.tools.layout_gateway import LayoutToolGateway
+from grox.tools.policy import GatewayPolicy
+from grox.tools.secrets import SecretBroker
+
+
+OFFICIAL_ENDPOINT = "https://api.openai.com/v1/responses"
+OFFICIAL_ORIGIN = "https://api.openai.com"
+MODEL = "remote-model-sentinel"
+ALIAS = "openai-primary"
+SECRET = "INTEGRATION-OPENAI-PROBE-SECRET"
+
+
+class FakeResponse:
+    status = 200
+
+    def read(self, limit: int) -> bytes:
+        return json.dumps({"id": MODEL, "object": "model", "owned_by": "openai"}).encode()
+
+
+class FakeHTTPSConnection:
+    requests: list[tuple[str, str, dict[str, str]]] = []
+
+    def __init__(self, host, port, **kwargs):
+        self.host = host
+        self.port = port
+        self.closed = False
+
+    def request(self, method, path, headers=None):
+        self.__class__.requests.append((method, path, dict(headers or {})))
+
+    def getresponse(self):
+        return FakeResponse()
+
+    def close(self):
+        self.closed = True
+
+
+class ConfiguredOpenAIAuthenticatedModelProbeIntegrationTests(unittest.TestCase):
+    def test_environment_discovery_to_exact_authenticated_visibility_preserves_later_state_boundaries(self):
+        FakeHTTPSConnection.requests = []
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            assets = root / "assets"
+            state = root / "state"
+            work = root / "work"
+            for path in (assets, state, work):
+                path.mkdir()
+            layout = VesselLayout.separated(
+                asset_root=assets,
+                state_root=state,
+                work_root=work,
+            )
+            gateway = LayoutToolGateway(
+                layout,
+                policy=GatewayPolicy(
+                    network_enabled=True,
+                    allowed_origins=frozenset({OFFICIAL_ORIGIN}),
+                    max_response_bytes=4096,
+                ),
+                secret_broker=SecretBroker({ALIAS: SECRET}),
+            )
+            env = {
+                "GROX_REASONER_PROVIDER": "openai",
+                "GROX_REASONER_MODEL": MODEL,
+                "GROX_REASONER_ENDPOINT": OFFICIAL_ENDPOINT,
+                "GROX_REASONER_CREDENTIAL_ALIAS": ALIAS,
+            }
+            with patch.dict(os.environ, env, clear=False):
+                config = nonsecret_reasoner_config_from_env()
+            resource = ConfiguredCognitionDiscovery(config).inventory()["resources"][0]
+            order = MissionOrder.new(
+                "MSN-openai-probe-integration",
+                "verify configured OpenAI model visibility",
+                "verify configured OpenAI model visibility",
+                MissionMode.inspect,
+                "application-security-engineer",
+                allowed_actions=("net_fetch", "secret_use"),
+                parameters={
+                    "operation": "configured_openai_authenticated_model_probe",
+                    "resource_id": resource["resource_id"],
+                    "provider_kind": "openai",
+                    "model": MODEL,
+                    "endpoint": OFFICIAL_ENDPOINT,
+                    "credential_alias": ALIAS,
+                    "allowed_origins": [OFFICIAL_ORIGIN],
+                    "secret_grants": [ALIAS],
+                },
+            ).seal()
+
+            with patch(
+                "grox.tools.layout_gateway.http.client.HTTPSConnection",
+                FakeHTTPSConnection,
+            ):
+                result = ConfiguredOpenAIAuthenticatedModelProbe(config, gateway).probe(
+                    order=order
+                )
+
+        self.assertEqual(result["resource_id"], resource["resource_id"])
+        self.assertEqual(result["classification"], "authenticated_model_visible")
+        self.assertTrue(result["credential_use_authorized"])
+        self.assertTrue(result["credential_accepted_for_model_visibility"])
+        self.assertTrue(result["secret_materialized"])
+        self.assertTrue(result["network_invoked"])
+        self.assertFalse(result["response_body_returned"])
+        self.assertFalse(result["cognition_invoked"])
+        self.assertFalse(result["ready"])
+        self.assertFalse(result["qualified_fit"])
+        self.assertFalse(result["selected"])
+        self.assertFalse(result["observed"])
+        self.assertFalse(result["mission_created"])
+        self.assertFalse(result["authority_changed"])
+        self.assertNotIn(SECRET, repr(result))
+        self.assertEqual(len(FakeHTTPSConnection.requests), 1)
+        method, path, headers = FakeHTTPSConnection.requests[0]
+        self.assertEqual(method, "GET")
+        self.assertEqual(path, f"/v1/models/{MODEL}")
+        self.assertEqual(headers["Authorization"], f"Bearer {SECRET}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/mutation/run_critical_invariants.py
+++ b/tests/mutation/run_critical_invariants.py
@@ -248,6 +248,14 @@ SPECS: tuple[MutationSpec, ...] = (
         nodeid="tests/unit/test_configured_remote_reasoner.py::ConfiguredRemoteReasonerActivationTests::test_authorization_awareness_operation_cannot_materialize_or_construct_provider",
     ),
     MutationSpec(
+        name="openai-authenticated-probe-official-endpoint-boundary",
+        invariant="A non-official configured endpoint must never cross the authenticated OpenAI secret/network boundary.",
+        path="src/grox/tools/layout_gateway.py",
+        old='        if responses_endpoint != _OFFICIAL_OPENAI_RESPONSES_ENDPOINT:\n            raise ToolDenied("authenticated OpenAI probe requires the exact official Responses endpoint")\n',
+        new='        if False and responses_endpoint != _OFFICIAL_OPENAI_RESPONSES_ENDPOINT:\n            raise ToolDenied("authenticated OpenAI probe requires the exact official Responses endpoint")\n',
+        nodeid="tests/unit/test_openai_authenticated_model_probe.py::OpenAIAuthenticatedModelProbeTests::test_non_official_configured_endpoint_never_receives_credential",
+    ),
+    MutationSpec(
         name="ci-action-immutable-pin",
         invariant="Third-party GitHub Actions must remain pinned to immutable full commit SHAs.",
         path=".github/workflows/ci.yml",

--- a/tests/unit/test_configured_openai_probe.py
+++ b/tests/unit/test_configured_openai_probe.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from grox.cognition_discovery import ConfiguredCognitionDiscovery
+from grox.configured_openai_probe import (
+    ConfiguredOpenAIAuthenticatedModelProbe,
+    ConfiguredOpenAIAuthenticatedModelProbeError,
+)
+from grox.contracts import MissionMode, MissionOrder
+from grox.runtime_layout import VesselLayout
+from grox.tools.layout_gateway import LayoutToolGateway
+from grox.tools.policy import GatewayPolicy
+from grox.tools.secrets import SecretBroker
+
+
+OFFICIAL_ENDPOINT = "https://api.openai.com/v1/responses"
+OFFICIAL_ORIGIN = "https://api.openai.com"
+MODEL = "remote-model-sentinel"
+ALIAS = "openai-primary"
+CONFIG = {
+    "GROX_REASONER_PROVIDER": "openai",
+    "GROX_REASONER_MODEL": MODEL,
+    "GROX_REASONER_ENDPOINT": OFFICIAL_ENDPOINT,
+    "GROX_REASONER_CREDENTIAL_ALIAS": ALIAS,
+}
+
+
+class TrackingSecretBroker(SecretBroker):
+    def __init__(self, secrets=None):
+        super().__init__(secrets)
+        self.materialize_calls: list[dict[str, str]] = []
+
+    def materialize_env(self, order, requested):
+        self.materialize_calls.append(dict(requested or {}))
+        return super().materialize_env(order, requested)
+
+
+class ConfiguredOpenAIAuthenticatedModelProbeTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def _gateway(self, secrets=None):
+        broker = TrackingSecretBroker(secrets)
+        gateway = LayoutToolGateway(
+            VesselLayout.legacy(Path(self.tempdir.name)),
+            policy=GatewayPolicy(
+                network_enabled=True,
+                allowed_origins=frozenset({OFFICIAL_ORIGIN}),
+            ),
+            secret_broker=broker,
+        )
+        return gateway, broker
+
+    @staticmethod
+    def _resource(config=CONFIG):
+        return ConfiguredCognitionDiscovery(config).inventory()["resources"][0]
+
+    def _order(
+        self,
+        *,
+        config=CONFIG,
+        seal=True,
+        resource_id=None,
+        provider_kind="openai",
+        model=MODEL,
+        endpoint=OFFICIAL_ENDPOINT,
+        credential_alias=ALIAS,
+        operation="configured_openai_authenticated_model_probe",
+        allowed_actions=("net_fetch", "secret_use"),
+        allowed_origins=(OFFICIAL_ORIGIN,),
+        secret_grants=(ALIAS,),
+    ):
+        resource = self._resource(config)
+        order = MissionOrder.new(
+            "MSN-configured-openai-probe",
+            "probe exact configured OpenAI model visibility",
+            "probe exact configured OpenAI model visibility",
+            MissionMode.inspect,
+            "application-security-engineer",
+            allowed_actions=allowed_actions,
+            parameters={
+                "operation": operation,
+                "resource_id": resource["resource_id"] if resource_id is None else resource_id,
+                "provider_kind": provider_kind,
+                "model": model,
+                "endpoint": endpoint,
+                "credential_alias": credential_alias,
+                "allowed_origins": list(allowed_origins),
+                "secret_grants": list(secret_grants),
+            },
+        )
+        return order.seal() if seal else order
+
+    def test_exact_configured_identity_is_forwarded_to_gateway_and_later_states_remain_false(self):
+        gateway, _ = self._gateway({ALIAS: "SECRET-SENTINEL"})
+        service = ConfiguredOpenAIAuthenticatedModelProbe(CONFIG, gateway)
+        expected = {
+            "schema": "grox-openai-authenticated-model-probe-v1",
+            "origin": OFFICIAL_ORIGIN,
+            "status": 200,
+            "classification": "authenticated_model_visible",
+            "requested_model": MODEL,
+            "model_identity": MODEL,
+            "metadata_valid": True,
+            "credential_alias": ALIAS,
+            "credential_accepted_for_model_visibility": True,
+            "credential_rejected": False,
+            "secret_materialized": True,
+            "network_invoked": True,
+            "response_body_returned": False,
+            "cognition_invoked": False,
+            "ready": False,
+            "qualified_fit": False,
+            "selected": False,
+            "authority_changed": False,
+        }
+        with patch.object(gateway, "openai_model_probe", return_value=expected) as probe_mock:
+            result = service.probe(order=self._order())
+
+        resource = self._resource()
+        probe_mock.assert_called_once_with(
+            self._order(),
+            resource_id=resource["resource_id"],
+            responses_endpoint=OFFICIAL_ENDPOINT,
+            model=MODEL,
+            credential_alias=ALIAS,
+        )
+        self.assertEqual(result["resource_id"], resource["resource_id"])
+        self.assertTrue(result["credential_use_authorized"])
+        self.assertFalse(result["ready"])
+        self.assertFalse(result["qualified_fit"])
+        self.assertFalse(result["selected"])
+        self.assertFalse(result["observed"])
+        self.assertFalse(result["mission_created"])
+        self.assertFalse(result["auto_selection"])
+
+    def test_wrong_resource_or_operation_fails_before_gateway_or_materialization(self):
+        gateway, broker = self._gateway({ALIAS: "SECRET-SENTINEL"})
+        service = ConfiguredOpenAIAuthenticatedModelProbe(CONFIG, gateway)
+        cases = (
+            self._order(resource_id="cognition:configured:openai:wrong"),
+            self._order(operation="configured_cognition_remote_reasoner_activation"),
+        )
+        for order in cases:
+            with self.subTest(parameters=order.parameters):
+                with patch.object(
+                    gateway,
+                    "openai_model_probe",
+                    side_effect=AssertionError("identity mismatch must fail before gateway probe"),
+                ) as probe_mock:
+                    with self.assertRaises(ConfiguredOpenAIAuthenticatedModelProbeError):
+                        service.probe(order=order)
+                probe_mock.assert_not_called()
+        self.assertEqual(broker.materialize_calls, [])
+
+    def test_non_official_configured_endpoint_fails_before_gateway_or_materialization(self):
+        config = {
+            **CONFIG,
+            "GROX_REASONER_ENDPOINT": "https://compatible.example/v1/responses",
+        }
+        gateway, broker = self._gateway({ALIAS: "SECRET-SENTINEL"})
+        service = ConfiguredOpenAIAuthenticatedModelProbe(config, gateway)
+        order = self._order(
+            config=config,
+            endpoint="https://compatible.example/v1/responses",
+            allowed_origins=("https://compatible.example",),
+        )
+        with patch.object(
+            gateway,
+            "openai_model_probe",
+            side_effect=AssertionError("compatible endpoint must not reach credential-bearing gateway"),
+        ) as probe_mock:
+            with self.assertRaisesRegex(
+                ConfiguredOpenAIAuthenticatedModelProbeError,
+                "exact official Responses endpoint",
+            ):
+                service.probe(order=order)
+        probe_mock.assert_not_called()
+        self.assertEqual(broker.materialize_calls, [])
+
+    def test_unsealed_order_fails_without_becoming_sealed(self):
+        gateway, broker = self._gateway({ALIAS: "SECRET-SENTINEL"})
+        service = ConfiguredOpenAIAuthenticatedModelProbe(CONFIG, gateway)
+        order = self._order(seal=False)
+        with patch.object(gateway, "openai_model_probe") as probe_mock:
+            with self.assertRaisesRegex(
+                ConfiguredOpenAIAuthenticatedModelProbeError,
+                "already sealed",
+            ):
+                service.probe(order=order)
+        self.assertFalse(order.sealed)
+        self.assertEqual(broker.materialize_calls, [])
+        probe_mock.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_configured_openai_probe.py
+++ b/tests/unit/test_configured_openai_probe.py
@@ -121,12 +121,13 @@ class ConfiguredOpenAIAuthenticatedModelProbeTests(unittest.TestCase):
             "selected": False,
             "authority_changed": False,
         }
+        order = self._order()
         with patch.object(gateway, "openai_model_probe", return_value=expected) as probe_mock:
-            result = service.probe(order=self._order())
+            result = service.probe(order=order)
 
         resource = self._resource()
         probe_mock.assert_called_once_with(
-            self._order(),
+            order,
             resource_id=resource["resource_id"],
             responses_endpoint=OFFICIAL_ENDPOINT,
             model=MODEL,

--- a/tests/unit/test_openai_authenticated_model_probe.py
+++ b/tests/unit/test_openai_authenticated_model_probe.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+from pathlib import Path
+import json
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from grox.cognition_discovery import ConfiguredCognitionDiscovery
+from grox.contracts import MissionMode, MissionOrder
+from grox.runtime_layout import VesselLayout
+from grox.tools.gateway import ToolDenied
+from grox.tools.layout_gateway import LayoutToolGateway
+from grox.tools.policy import GatewayPolicy
+from grox.tools.secrets import SecretBroker
+
+
+OFFICIAL_ENDPOINT = "https://api.openai.com/v1/responses"
+OFFICIAL_ORIGIN = "https://api.openai.com"
+MODEL = "remote-model-sentinel"
+ALIAS = "openai-primary"
+CONFIG = {
+    "GROX_REASONER_PROVIDER": "openai",
+    "GROX_REASONER_MODEL": MODEL,
+    "GROX_REASONER_ENDPOINT": OFFICIAL_ENDPOINT,
+    "GROX_REASONER_CREDENTIAL_ALIAS": ALIAS,
+}
+
+
+class TrackingSecretBroker(SecretBroker):
+    def __init__(self, secrets=None):
+        super().__init__(secrets)
+        self.materialize_calls: list[dict[str, str]] = []
+
+    def materialize_env(self, order, requested):
+        self.materialize_calls.append(dict(requested or {}))
+        return super().materialize_env(order, requested)
+
+
+class FakeResponse:
+    def __init__(self, status: int, payload: bytes):
+        self.status = status
+        self._payload = payload
+
+    def read(self, limit: int) -> bytes:
+        return self._payload
+
+
+class FakeHTTPSConnection:
+    response = FakeResponse(500, b"{}")
+    instances: list["FakeHTTPSConnection"] = []
+
+    def __init__(self, host, port, **kwargs):
+        self.host = host
+        self.port = port
+        self.kwargs = kwargs
+        self.request_call = None
+        self.closed = False
+        self.__class__.instances.append(self)
+
+    def request(self, method, path, headers=None):
+        self.request_call = (method, path, dict(headers or {}))
+
+    def getresponse(self):
+        return self.__class__.response
+
+    def close(self):
+        self.closed = True
+
+
+class OpenAIAuthenticatedModelProbeTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        FakeHTTPSConnection.instances = []
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    @staticmethod
+    def _resource(config=CONFIG) -> dict:
+        return ConfiguredCognitionDiscovery(config).inventory()["resources"][0]
+
+    def _gateway(self, *, secrets=None, allowed_origins=(OFFICIAL_ORIGIN,)):
+        broker = TrackingSecretBroker(secrets)
+        policy = GatewayPolicy(
+            network_enabled=True,
+            allowed_origins=frozenset(allowed_origins),
+            max_response_bytes=4096,
+        )
+        gateway = LayoutToolGateway(
+            VesselLayout.legacy(Path(self.tempdir.name)),
+            policy=policy,
+            secret_broker=broker,
+        )
+        return gateway, broker
+
+    def _order(
+        self,
+        *,
+        seal=True,
+        endpoint=OFFICIAL_ENDPOINT,
+        resource_id=None,
+        provider_kind="openai",
+        model=MODEL,
+        credential_alias=ALIAS,
+        allowed_actions=("net_fetch", "secret_use"),
+        allowed_origins=(OFFICIAL_ORIGIN,),
+        secret_grants=(ALIAS,),
+        operation="configured_openai_authenticated_model_probe",
+    ) -> MissionOrder:
+        resource = self._resource(
+            {
+                **CONFIG,
+                "GROX_REASONER_ENDPOINT": endpoint,
+                "GROX_REASONER_MODEL": model,
+            }
+        )
+        order = MissionOrder.new(
+            "MSN-openai-model-probe",
+            "probe configured OpenAI model visibility",
+            "probe configured OpenAI model visibility",
+            MissionMode.inspect,
+            "application-security-engineer",
+            allowed_actions=allowed_actions,
+            parameters={
+                "operation": operation,
+                "resource_id": resource["resource_id"] if resource_id is None else resource_id,
+                "provider_kind": provider_kind,
+                "model": model,
+                "endpoint": endpoint,
+                "credential_alias": credential_alias,
+                "allowed_origins": list(allowed_origins),
+                "secret_grants": list(secret_grants),
+            },
+        )
+        return order.seal() if seal else order
+
+    def _probe(self, gateway, order, *, endpoint=OFFICIAL_ENDPOINT, model=MODEL, alias=ALIAS):
+        return gateway.openai_model_probe(
+            order,
+            resource_id=order.parameters["resource_id"],
+            responses_endpoint=endpoint,
+            model=model,
+            credential_alias=alias,
+        )
+
+    def test_exact_official_200_proves_authenticated_model_visibility_without_secret_or_body_exposure(self):
+        secret = "OPENAI-PROBE-SECRET-SENTINEL"
+        FakeHTTPSConnection.response = FakeResponse(
+            200,
+            json.dumps({"id": MODEL, "object": "model", "owned_by": "openai"}).encode(),
+        )
+        gateway, broker = self._gateway(secrets={ALIAS: secret})
+        order = self._order()
+
+        with patch("grox.tools.layout_gateway.http.client.HTTPSConnection", FakeHTTPSConnection):
+            result = self._probe(gateway, order)
+
+        self.assertEqual(result["classification"], "authenticated_model_visible")
+        self.assertTrue(result["credential_accepted_for_model_visibility"])
+        self.assertFalse(result["credential_rejected"])
+        self.assertEqual(result["model_identity"], MODEL)
+        self.assertTrue(result["metadata_valid"])
+        self.assertTrue(result["secret_materialized"])
+        self.assertTrue(result["network_invoked"])
+        self.assertFalse(result["response_body_returned"])
+        self.assertFalse(result["cognition_invoked"])
+        self.assertFalse(result["ready"])
+        self.assertFalse(result["qualified_fit"])
+        self.assertFalse(result["selected"])
+        self.assertFalse(result["authority_changed"])
+        self.assertNotIn(secret, repr(result))
+        self.assertNotIn("owned_by", repr(result))
+        self.assertEqual(
+            broker.materialize_calls,
+            [{"GROX_OPENAI_PROBE_CREDENTIAL": ALIAS}],
+        )
+        self.assertEqual(len(FakeHTTPSConnection.instances), 1)
+        conn = FakeHTTPSConnection.instances[0]
+        self.assertEqual((conn.host, conn.port), ("api.openai.com", 443))
+        method, path, headers = conn.request_call
+        self.assertEqual(method, "GET")
+        self.assertEqual(path, f"/v1/models/{MODEL}")
+        self.assertEqual(headers["Authorization"], f"Bearer {secret}")
+        self.assertTrue(conn.closed)
+
+    def test_401_records_rejection_without_manufacturing_visibility_or_readiness(self):
+        FakeHTTPSConnection.response = FakeResponse(401, b'{"error":{"message":"invalid"}}')
+        gateway, _ = self._gateway(secrets={ALIAS: "REJECTED-SENTINEL"})
+        with patch("grox.tools.layout_gateway.http.client.HTTPSConnection", FakeHTTPSConnection):
+            result = self._probe(gateway, self._order())
+        self.assertEqual(result["classification"], "credential_rejected")
+        self.assertTrue(result["credential_rejected"])
+        self.assertFalse(result["credential_accepted_for_model_visibility"])
+        self.assertIsNone(result["model_identity"])
+        self.assertFalse(result["ready"])
+
+    def test_200_with_wrong_model_identity_is_indeterminate(self):
+        FakeHTTPSConnection.response = FakeResponse(
+            200,
+            json.dumps({"id": "different-model", "object": "model"}).encode(),
+        )
+        gateway, _ = self._gateway(secrets={ALIAS: "SECRET-SENTINEL"})
+        with patch("grox.tools.layout_gateway.http.client.HTTPSConnection", FakeHTTPSConnection):
+            result = self._probe(gateway, self._order())
+        self.assertEqual(result["classification"], "indeterminate")
+        self.assertFalse(result["metadata_valid"])
+        self.assertFalse(result["credential_accepted_for_model_visibility"])
+        self.assertIsNone(result["model_identity"])
+
+    def test_non_official_configured_endpoint_never_receives_credential(self):
+        endpoint = "https://compatible.example/v1/responses"
+        gateway, broker = self._gateway(
+            secrets={ALIAS: "DO-NOT-EXFILTRATE-SENTINEL"},
+            allowed_origins=(OFFICIAL_ORIGIN, "https://compatible.example"),
+        )
+        order = self._order(
+            endpoint=endpoint,
+            allowed_origins=("https://compatible.example",),
+        )
+        with patch(
+            "grox.tools.layout_gateway.http.client.HTTPSConnection",
+            side_effect=AssertionError("non-official endpoint must fail before network"),
+        ) as connection_mock:
+            with self.assertRaisesRegex(ToolDenied, "exact official Responses endpoint"):
+                self._probe(gateway, order, endpoint=endpoint)
+        self.assertEqual(broker.materialize_calls, [])
+        connection_mock.assert_not_called()
+
+    def test_unsealed_order_fails_without_becoming_sealed_or_touching_secret_or_network(self):
+        gateway, broker = self._gateway(secrets={ALIAS: "SECRET-SENTINEL"})
+        order = self._order(seal=False)
+        with patch(
+            "grox.tools.layout_gateway.http.client.HTTPSConnection",
+            side_effect=AssertionError("unsealed Order must fail before network"),
+        ) as connection_mock:
+            with self.assertRaisesRegex(ToolDenied, "already sealed"):
+                self._probe(gateway, order)
+        self.assertFalse(order.sealed)
+        self.assertEqual(broker.materialize_calls, [])
+        connection_mock.assert_not_called()
+
+    def test_exact_identity_actions_origin_and_alias_grant_are_required(self):
+        cases = (
+            {"order_kwargs": {"operation": "other-operation"}, "message": "identity mismatch"},
+            {"order_kwargs": {"resource_id": "cognition:configured:openai:wrong"}, "message": "identity mismatch"},
+            {"order_kwargs": {"provider_kind": "other"}, "message": "identity mismatch"},
+            {"order_kwargs": {"credential_alias": "other-alias"}, "message": "identity mismatch"},
+            {"order_kwargs": {"allowed_actions": ("secret_use",)}, "message": "net_fetch"},
+            {"order_kwargs": {"allowed_actions": ("net_fetch",)}, "message": "secret_use"},
+            {"order_kwargs": {"allowed_origins": ()}, "message": "origin not granted"},
+        )
+        for case in cases:
+            with self.subTest(case=case):
+                gateway, broker = self._gateway(
+                    secrets={ALIAS: "SECRET-SENTINEL", "other-alias": "OTHER-SENTINEL"}
+                )
+                order = self._order(**case["order_kwargs"])
+                with patch(
+                    "grox.tools.layout_gateway.http.client.HTTPSConnection",
+                    side_effect=AssertionError("failed authority must not invoke network"),
+                ):
+                    with self.assertRaisesRegex(ToolDenied, case["message"]):
+                        self._probe(gateway, order)
+                self.assertEqual(broker.materialize_calls, [])
+
+        gateway, broker = self._gateway(secrets={ALIAS: "SECRET-SENTINEL"})
+        order = self._order(secret_grants=("other-alias",))
+        with patch(
+            "grox.tools.layout_gateway.http.client.HTTPSConnection",
+            side_effect=AssertionError("denied alias grant must not invoke network"),
+        ):
+            with self.assertRaisesRegex(ToolDenied, "credential materialization denied"):
+                self._probe(gateway, order)
+        self.assertEqual(
+            broker.materialize_calls,
+            [{"GROX_OPENAI_PROBE_CREDENTIAL": ALIAS}],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_openai_authenticated_model_probe.py
+++ b/tests/unit/test_openai_authenticated_model_probe.py
@@ -216,7 +216,7 @@ class OpenAIAuthenticatedModelProbeTests(unittest.TestCase):
         )
         order = self._order(
             endpoint=endpoint,
-            allowed_origins=("https://compatible.example",),
+            allowed_origins=(OFFICIAL_ORIGIN, "https://compatible.example"),
         )
         with patch(
             "grox.tools.layout_gateway.http.client.HTTPSConnection",

--- a/tests/unit/test_openai_authenticated_model_probe.py
+++ b/tests/unit/test_openai_authenticated_model_probe.py
@@ -243,7 +243,6 @@ class OpenAIAuthenticatedModelProbeTests(unittest.TestCase):
     def test_exact_identity_actions_origin_and_alias_grant_are_required(self):
         cases = (
             {"order_kwargs": {"operation": "other-operation"}, "message": "identity mismatch"},
-            {"order_kwargs": {"resource_id": "cognition:configured:openai:wrong"}, "message": "identity mismatch"},
             {"order_kwargs": {"provider_kind": "other"}, "message": "identity mismatch"},
             {"order_kwargs": {"credential_alias": "other-alias"}, "message": "identity mismatch"},
             {"order_kwargs": {"allowed_actions": ("secret_use",)}, "message": "net_fetch"},


### PR DESCRIPTION
Closes #170
Parent: #115

## Scope

Development-first bounded implementation from canonical `main@12cfc9716722a3e706cab35606b876bfae609f39`.

This adds the first credential-bearing remote-provider evidence path for configured cognition while preserving GroX's authority/state boundaries.

- configured identity is resolved by `ConfiguredOpenAIAuthenticatedModelProbe` using the existing exact credential-use authorization contract;
- only provider kind `openai` at exact endpoint `https://api.openai.com/v1/responses` is eligible;
- `LayoutToolGateway.openai_model_probe()` requires an already-sealed Mission Order, exact operation/resource/provider/model/endpoint/alias identity, `net_fetch`, `secret_use`, exact alias grant, exact official-origin Mission grant, host policy permission, and the exact broker alias;
- one bounded HTTPS `GET /v1/models/{model}` may be issued to `api.openai.com`;
- only exact `200` + exact `{id, object:model}` becomes `authenticated_model_visible`; `401` is `credential_rejected`; all other outcomes are conservative `indeterminate`;
- response body and credential value are never returned; credential cleanup runs even across connection/TLS failure;
- no cognition request occurs;
- `ready`, `qualified_fit`, `selected`, and `observed` remain false; no Mission creation, auto-selection, fallback/routing, release/NCI/Apex/A8 advancement.

## Exact scope

Exactly six runtime/test files, zero documentation/workflow files:

1. `src/grox/configured_openai_probe.py`
2. `src/grox/tools/layout_gateway.py`
3. `tests/integration/test_configured_openai_probe.py`
4. `tests/mutation/run_critical_invariants.py`
5. `tests/unit/test_configured_openai_probe.py`
6. `tests/unit/test_openai_authenticated_model_probe.py`

## Exact-head qualification

- exact head: `d51737929a70f4dc855086a06f7438055674d4a6`
- CI-tested synthetic merge: `2e18be9aebf254cd34e8daf1aa8ff395016bd3d7`
- CI-tested synthetic tree: `b19c875b0e059c7136e49cf917763a27d868a055`
- GroX CI #573 / run `32954640366`: PASS Wheel bootstrap + Python 3.11–3.14
- Python 3.12 job `98133538991`: Vessel Health **10 PASS / 0 WARN / 0 FAIL / 0 UNKNOWN**
- pytest **451 passed / 2 skipped / 505 subtests**
- unittest **453 tests OK / 2 skipped**
- critical mutations **27/27 KILLED**, zero survivors, source restored clean
- new permanent mutation `openai-authenticated-probe-official-endpoint-boundary`: KILLED
- Vessel-health mutations **7/7**, reconstitution **9/9**, operational drift **4/4**, source provenance **6/6** KILLED with clean restoration
- Post-Apex integrated operational qualification: PASS; GorXu remains sole orchestrator; no new Apex stage, release decision, or qualification self-claim
- compile/diff hygiene: PASS

## Claim boundary

A qualifying exact `200` proves only that the exact configured credential was accepted for access to metadata for the exact configured model at observation time. It does **not** prove broad credential validity, provider readiness, successful configured cognition semantics, Mission-specific model fitness, provider selection/fallback, or adaptive routing. Parent #115 remains open.