### PR TITLE
Qualify governed configured OpenAI cognition invocation

### DIFF
--- a/src/grox/configured_openai_cognition.py
+++ b/src/grox/configured_openai_cognition.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+from .configured_credential_use_authorization import (
+    ConfiguredCredentialUseAuthorization,
+    ConfiguredCredentialUseAuthorizationError,
+)
+from .contracts import MissionOrder
+from .reasoning.base import ReasoningError
+from .reasoning.contracts import MissionInterpretation
+from .reasoning.openai_responses import OpenAIResponsesProvider
+from .tools.gateway import ToolDenied
+from .tools.layout_gateway import LayoutToolGateway
+
+
+class ConfiguredOpenAICognitionError(RuntimeError):
+    """Configured governed OpenAI cognition failed closed."""
+
+
+@dataclass(frozen=True)
+class ConfiguredOpenAICognitionResult:
+    """Successful exact configured cognition result plus privacy-minimized evidence."""
+
+    resource_id: str
+    provider_kind: str
+    model: str
+    endpoint: str
+    credential_alias: str
+    response_id: str | None
+    response_model: str | None
+    _interpretation: MissionInterpretation = field(repr=False, compare=False)
+
+    @property
+    def interpretation(self) -> MissionInterpretation:
+        return self._interpretation
+
+    def evidence(self) -> dict[str, Any]:
+        return {
+            "schema": "grox-configured-openai-cognition-v1",
+            "resource_id": self.resource_id,
+            "provider_kind": self.provider_kind,
+            "model": self.model,
+            "endpoint": self.endpoint,
+            "credential_alias": self.credential_alias,
+            "response_id": self.response_id,
+            "response_model": self.response_model,
+            "credential_use_authorized": True,
+            "secret_materialized": True,
+            "network_invoked": True,
+            "cognition_invoked": True,
+            "cognition_succeeded": True,
+            "structured_interpretation_valid": True,
+            "ready": True,
+            "qualified_fit": False,
+            "selected": False,
+            "observed": False,
+            "mission_created": False,
+            "authority_changed": False,
+            "auto_selection": False,
+            "raw_response_returned": False,
+        }
+
+
+class ConfiguredOpenAICognition:
+    """Invoke one exact configured official OpenAI reasoner through the Tool Gateway."""
+
+    operation = "configured_openai_cognition_invoke"
+    official_responses_endpoint = "https://api.openai.com/v1/responses"
+
+    def __init__(self, config: Mapping[str, Any], gateway: LayoutToolGateway):
+        if not isinstance(config, Mapping):
+            raise TypeError("config must be a mapping")
+        if not isinstance(gateway, LayoutToolGateway):
+            raise TypeError("gateway must be a LayoutToolGateway")
+        self._config = dict(config)
+        self._gateway = gateway
+        self._authorization = ConfiguredCredentialUseAuthorization(self._config, gateway)
+
+    def invoke(
+        self,
+        *,
+        order: MissionOrder,
+        roster: list[dict[str, Any]],
+    ) -> ConfiguredOpenAICognitionResult:
+        if not isinstance(order, MissionOrder):
+            raise TypeError("order must be a MissionOrder")
+        if not isinstance(roster, list) or not all(isinstance(item, dict) for item in roster):
+            raise TypeError("roster must be a list of mappings")
+
+        try:
+            authorization = self._authorization.inventory(
+                order=order,
+                expected_operation=self.operation,
+            )
+        except ConfiguredCredentialUseAuthorizationError as exc:
+            raise ConfiguredOpenAICognitionError(
+                "configured OpenAI cognition requires an already sealed Mission Order"
+            ) from exc
+
+        resources = authorization.get("resources") or []
+        if authorization.get("status") != "ok" or len(resources) != 1:
+            raise ConfiguredOpenAICognitionError(
+                "configured OpenAI cognition is not applicable to current configured cognition"
+            )
+        item = resources[0]
+        if item.get("provider_kind") != "openai":
+            raise ConfiguredOpenAICognitionError(
+                "configured OpenAI cognition requires provider kind openai"
+            )
+        if item.get("endpoint") != self.official_responses_endpoint:
+            raise ConfiguredOpenAICognitionError(
+                "configured OpenAI cognition requires the exact official Responses endpoint"
+            )
+        if item.get("credential_use_authorized") is not True:
+            status = str(authorization.get("authorization_status") or "denied")
+            raise ConfiguredOpenAICognitionError(
+                f"configured OpenAI cognition denied: {status}"
+            )
+
+        alias = item.get("credential_alias")
+        if not isinstance(alias, str) or not alias:
+            raise ConfiguredOpenAICognitionError(
+                "configured OpenAI cognition has no exact credential alias"
+            )
+        if not order.commander_intent or len(order.commander_intent) > 20_000:
+            raise ConfiguredOpenAICognitionError(
+                "configured OpenAI cognition requires bounded Commander intent"
+            )
+
+        try:
+            response = self._gateway.openai_responses_cognition(
+                order,
+                resource_id=str(item["resource_id"]),
+                responses_endpoint=str(item["endpoint"]),
+                model=str(item["model"]),
+                credential_alias=alias,
+                directive=order.commander_intent,
+                roster=roster,
+            )
+            payload = response["_payload"]
+            interpretation = OpenAIResponsesProvider.interpretation_from_payload(
+                payload,
+                expected_intent=order.commander_intent,
+            )
+        except (ToolDenied, ReasoningError, KeyError, TypeError, ValueError, TimeoutError) as exc:
+            raise ConfiguredOpenAICognitionError(
+                f"configured OpenAI cognition failed closed: {exc}"
+            ) from exc
+
+        return ConfiguredOpenAICognitionResult(
+            resource_id=str(item["resource_id"]),
+            provider_kind="openai",
+            model=str(item["model"]),
+            endpoint=self.official_responses_endpoint,
+            credential_alias=alias,
+            response_id=response.get("response_id"),
+            response_model=response.get("response_model"),
+            _interpretation=interpretation,
+        )

--- a/src/grox/configured_openai_cognition.py
+++ b/src/grox/configured_openai_cognition.py
@@ -9,9 +9,7 @@ from .configured_credential_use_authorization import (
     ConfiguredCredentialUseAuthorizationError,
 )
 from .contracts import MissionOrder
-from .reasoning.base import ReasoningError
 from .reasoning.contracts import MissionInterpretation
-from .reasoning.openai_responses import OpenAIResponsesProvider
 from .tools.gateway import ToolDenied
 from .tools.layout_gateway import LayoutToolGateway
 
@@ -140,12 +138,12 @@ class ConfiguredOpenAICognition:
                 directive=order.commander_intent,
                 roster=roster,
             )
-            payload = response["_payload"]
-            interpretation = OpenAIResponsesProvider.interpretation_from_payload(
-                payload,
-                expected_intent=order.commander_intent,
-            )
-        except (ToolDenied, ReasoningError, KeyError, TypeError, ValueError, TimeoutError) as exc:
+            interpretation = response["interpretation"]
+            if not isinstance(interpretation, MissionInterpretation):
+                raise TypeError("gateway returned invalid structured interpretation")
+            if interpretation.commander_intent != order.commander_intent:
+                raise ValueError("gateway interpretation Commander intent mismatch")
+        except (ToolDenied, KeyError, TypeError, ValueError, TimeoutError) as exc:
             raise ConfiguredOpenAICognitionError(
                 f"configured OpenAI cognition failed closed: {exc}"
             ) from exc

--- a/src/grox/reasoning/openai_responses.py
+++ b/src/grox/reasoning/openai_responses.py
@@ -49,8 +49,14 @@ class OpenAIResponsesProvider:
             total_tokens=token("total_tokens",usage),
         )
 
-    def interpret(self, directive: str, *, roster: list[dict[str, Any]]) -> MissionInterpretation:
-        self._last_usage=None
+    @staticmethod
+    def build_interpret_body(*, model: str, directive: str, roster: list[dict[str, Any]]) -> dict[str, Any]:
+        if not isinstance(model, str) or not model:
+            raise ValueError("model is required")
+        if not isinstance(directive, str) or not directive:
+            raise ValueError("directive is required")
+        if not isinstance(roster, list) or not all(isinstance(item, dict) for item in roster):
+            raise ValueError("roster must be a list of mappings")
         directory_json=json.dumps(roster, ensure_ascii=False, separators=(",",":"))
         schema=MissionInterpretation.json_schema()
         stable_prefix=(
@@ -60,18 +66,38 @@ class OpenAIResponsesProvider:
         user=(stable_prefix + "Commander directive:\n" + directive +
               "\n\nProduce a structured Mission interpretation with at least two strategy options when meaningful.")
         cache_material=(
-            self.model + "\n" + _SYSTEM + "\n" + directory_json + "\n" +
+            model + "\n" + _SYSTEM + "\n" + directory_json + "\n" +
             json.dumps(schema,ensure_ascii=False,separators=(",",":"),sort_keys=True)
         )
         cache_key="grox-cognitive-"+hashlib.sha256(cache_material.encode("utf-8")).hexdigest()[:32]
-        body={
-            "model": self.model,
+        return {
+            "model": model,
             "store": False,
             "instructions": _SYSTEM,
             "input": user,
             "prompt_cache_key": cache_key,
             "text": {"format": {"type":"json_schema","name":"grox_mission_interpretation","strict":True,"schema":schema}},
         }
+
+    @classmethod
+    def interpretation_from_payload(
+        cls,
+        payload: dict[str, Any],
+        *,
+        expected_intent: str,
+    ) -> MissionInterpretation:
+        if not isinstance(payload, dict):
+            raise ReasoningError("reasoning provider returned a non-object response")
+        text=cls._output_text(payload)
+        try:
+            raw=json.loads(text)
+            return MissionInterpretation.from_mapping(raw,expected_intent=expected_intent)
+        except (json.JSONDecodeError,ValueError) as e:
+            raise ReasoningError(f"invalid structured reasoning output: {e}") from e
+
+    def interpret(self, directive: str, *, roster: list[dict[str, Any]]) -> MissionInterpretation:
+        self._last_usage=None
+        body=self.build_interpret_body(model=self.model, directive=directive, roster=roster)
         req=Request(self.endpoint,data=json.dumps(body).encode("utf-8"),headers={"Authorization":f"Bearer {self.__api_key}","Content-Type":"application/json"},method="POST")
         try:
             with urlopen(req,timeout=self.timeout) as r:
@@ -82,12 +108,7 @@ class OpenAIResponsesProvider:
         except (URLError,TimeoutError,OSError,json.JSONDecodeError) as e:
             raise ReasoningError(f"reasoning provider failure: {e}") from e
         self._capture_usage(payload)
-        text=self._output_text(payload)
-        try:
-            raw=json.loads(text)
-            return MissionInterpretation.from_mapping(raw,expected_intent=directive)
-        except (json.JSONDecodeError,ValueError) as e:
-            raise ReasoningError(f"invalid structured reasoning output: {e}") from e
+        return self.interpretation_from_payload(payload, expected_intent=directive)
 
     @staticmethod
     def _output_text(payload: dict[str, Any]) -> str:

--- a/src/grox/tools/layout_gateway.py
+++ b/src/grox/tools/layout_gateway.py
@@ -6,6 +6,7 @@ import ssl
 from urllib.parse import quote
 
 from ..contracts import MissionOrder
+from ..reasoning.base import ReasoningError
 from ..reasoning.openai_responses import OpenAIResponsesProvider
 from ..runtime_layout import VesselLayout
 from .browser import BrowserRuntime
@@ -245,7 +246,9 @@ class LayoutToolGateway(ToolGateway):
         This provider-specific surface intentionally refuses arbitrary URLs,
         arbitrary JSON request bodies, and OpenAI tool declarations. The request
         shape is built internally from the exact sealed Commander intent and
-        supplied Standing Crew directory.
+        supplied Standing Crew directory. Raw provider response data never leaves
+        this gateway method; only the validated interpretation and bounded metadata
+        are returned.
         """
         if not isinstance(order, MissionOrder):
             raise TypeError("order must be a MissionOrder")
@@ -361,6 +364,15 @@ class LayoutToolGateway(ToolGateway):
                 raise ToolDenied("configured OpenAI cognition returned invalid JSON") from exc
             if not isinstance(payload, dict):
                 raise ToolDenied("configured OpenAI cognition returned a non-object response")
+            try:
+                interpretation = OpenAIResponsesProvider.interpretation_from_payload(
+                    payload,
+                    expected_intent=directive,
+                )
+            except ReasoningError as exc:
+                raise ToolDenied(
+                    "configured OpenAI cognition returned invalid structured interpretation"
+                ) from exc
 
             response_id = payload.get("id")
             if not isinstance(response_id, str) or not response_id or len(response_id) > 200:
@@ -368,16 +380,18 @@ class LayoutToolGateway(ToolGateway):
             response_model = payload.get("model")
             if not isinstance(response_model, str) or not response_model or len(response_model) > 200:
                 response_model = None
+            payload = None
             return {
                 "schema": "grox-openai-responses-cognition-transport-v1",
                 "origin": _OFFICIAL_OPENAI_ORIGIN,
                 "status": status,
                 "response_id": response_id,
                 "response_model": response_model,
-                "_payload": payload,
+                "interpretation": interpretation,
                 "secret_materialized": True,
                 "network_invoked": True,
                 "cognition_invoked": True,
+                "raw_response_returned": False,
                 "authority_changed": False,
             }
         except ToolDenied:

--- a/src/grox/tools/layout_gateway.py
+++ b/src/grox/tools/layout_gateway.py
@@ -6,6 +6,7 @@ import ssl
 from urllib.parse import quote
 
 from ..contracts import MissionOrder
+from ..reasoning.openai_responses import OpenAIResponsesProvider
 from ..runtime_layout import VesselLayout
 from .browser import BrowserRuntime
 from .gateway import ToolDenied, ToolGateway
@@ -18,6 +19,9 @@ _OFFICIAL_OPENAI_RESPONSES_ENDPOINT = "https://api.openai.com/v1/responses"
 _OFFICIAL_OPENAI_ORIGIN = "https://api.openai.com"
 _OPENAI_PROBE_OPERATION = "configured_openai_authenticated_model_probe"
 _OPENAI_PROBE_SECRET_ENV = "GROX_OPENAI_PROBE_CREDENTIAL"
+_OPENAI_COGNITION_OPERATION = "configured_openai_cognition_invoke"
+_OPENAI_COGNITION_SECRET_ENV = "GROX_OPENAI_COGNITION_CREDENTIAL"
+_OPENAI_COGNITION_MAX_REQUEST_BYTES = 262_144
 
 
 class LayoutToolGateway(ToolGateway):
@@ -219,6 +223,168 @@ class LayoutToolGateway(ToolGateway):
         except OSError as exc:
             raise ToolDenied(
                 "authenticated OpenAI probe network request failed within exact official origin"
+            ) from exc
+        finally:
+            api_key = None
+            if conn is not None:
+                conn.close()
+
+    def openai_responses_cognition(
+        self,
+        order: MissionOrder,
+        *,
+        resource_id: str,
+        responses_endpoint: str,
+        model: str,
+        credential_alias: str,
+        directive: str,
+        roster: list[dict],
+    ) -> dict:
+        """Invoke one bounded official OpenAI Responses cognition request.
+
+        This provider-specific surface intentionally refuses arbitrary URLs,
+        arbitrary JSON request bodies, and OpenAI tool declarations. The request
+        shape is built internally from the exact sealed Commander intent and
+        supplied Standing Crew directory.
+        """
+        if not isinstance(order, MissionOrder):
+            raise TypeError("order must be a MissionOrder")
+        if not order.sealed:
+            raise ToolDenied("configured OpenAI cognition requires an already sealed Mission Order")
+        self._allowed(order, "cognition_invoke")
+        self._allowed(order, "net_fetch")
+        self._allowed(order, "secret_use")
+        if not self.policy.network_enabled:
+            raise ToolDenied("network access disabled by host policy")
+        if responses_endpoint != _OFFICIAL_OPENAI_RESPONSES_ENDPOINT:
+            raise ToolDenied("configured OpenAI cognition requires the exact official Responses endpoint")
+        if not isinstance(model, str) or not model or len(model) > 160:
+            raise ToolDenied("configured OpenAI cognition requires a bounded model identity")
+        if not isinstance(credential_alias, str) or not credential_alias:
+            raise ToolDenied("configured OpenAI cognition requires an exact credential alias")
+        if directive != order.commander_intent:
+            raise ToolDenied("configured OpenAI cognition Commander intent mismatch")
+        if not isinstance(directive, str) or not directive or len(directive) > 20_000:
+            raise ToolDenied("configured OpenAI cognition requires bounded Commander intent")
+        if (
+            not isinstance(roster, list)
+            or len(roster) > 200
+            or not all(isinstance(item, dict) for item in roster)
+        ):
+            raise ToolDenied("configured OpenAI cognition requires a bounded roster")
+
+        parameters = order.parameters
+        exact = (
+            parameters.get("operation") == _OPENAI_COGNITION_OPERATION
+            and parameters.get("resource_id") == resource_id
+            and parameters.get("provider_kind") == "openai"
+            and parameters.get("model") == model
+            and parameters.get("endpoint") == responses_endpoint
+            and parameters.get("credential_alias") == credential_alias
+        )
+        if not exact:
+            raise ToolDenied("configured OpenAI cognition Mission identity mismatch")
+
+        origin, parsed = self._assert_url(order, responses_endpoint)
+        if (
+            origin != _OFFICIAL_OPENAI_ORIGIN
+            or parsed.path != "/v1/responses"
+            or parsed.query
+            or parsed.fragment
+        ):
+            raise ToolDenied("configured OpenAI cognition endpoint mismatch")
+
+        try:
+            body = OpenAIResponsesProvider.build_interpret_body(
+                model=model,
+                directive=directive,
+                roster=roster,
+            )
+            encoded = json.dumps(
+                body,
+                ensure_ascii=False,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        except (TypeError, ValueError) as exc:
+            raise ToolDenied("configured OpenAI cognition request construction failed") from exc
+        if len(encoded) > _OPENAI_COGNITION_MAX_REQUEST_BYTES:
+            raise ToolDenied(
+                f"configured OpenAI cognition request exceeds {_OPENAI_COGNITION_MAX_REQUEST_BYTES} bytes"
+            )
+
+        try:
+            secret_values, aliases = self.secret_broker.materialize_env(
+                order,
+                {_OPENAI_COGNITION_SECRET_ENV: credential_alias},
+            )
+        except SecretDenied as exc:
+            raise ToolDenied("configured OpenAI cognition credential materialization denied") from exc
+        if aliases != [credential_alias]:
+            secret_values.clear()
+            raise ToolDenied("configured OpenAI cognition credential identity mismatch")
+        api_key = secret_values.pop(_OPENAI_COGNITION_SECRET_ENV, None)
+        secret_values.clear()
+        if not isinstance(api_key, str) or not api_key:
+            raise ToolDenied("configured OpenAI cognition credential materialization produced no usable value")
+
+        conn = None
+        try:
+            conn = http.client.HTTPSConnection(
+                "api.openai.com",
+                443,
+                timeout=self.policy.network_timeout_seconds,
+                context=ssl.create_default_context(),
+            )
+            conn.request(
+                "POST",
+                "/v1/responses",
+                body=encoded,
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "User-Agent": "GroX/1.0",
+                    "Accept": "application/json",
+                    "Content-Type": "application/json",
+                },
+            )
+            response = conn.getresponse()
+            raw = response.read(self.policy.max_response_bytes + 1)
+            if len(raw) > self.policy.max_response_bytes:
+                raise ToolDenied(
+                    f"network response exceeds {self.policy.max_response_bytes} bytes"
+                )
+            status = int(response.status)
+            if status != 200:
+                raise ToolDenied(f"configured OpenAI cognition HTTP {status}")
+            try:
+                payload = json.loads(raw.decode("utf-8"))
+            except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+                raise ToolDenied("configured OpenAI cognition returned invalid JSON") from exc
+            if not isinstance(payload, dict):
+                raise ToolDenied("configured OpenAI cognition returned a non-object response")
+
+            response_id = payload.get("id")
+            if not isinstance(response_id, str) or not response_id or len(response_id) > 200:
+                response_id = None
+            response_model = payload.get("model")
+            if not isinstance(response_model, str) or not response_model or len(response_model) > 200:
+                response_model = None
+            return {
+                "schema": "grox-openai-responses-cognition-transport-v1",
+                "origin": _OFFICIAL_OPENAI_ORIGIN,
+                "status": status,
+                "response_id": response_id,
+                "response_model": response_model,
+                "_payload": payload,
+                "secret_materialized": True,
+                "network_invoked": True,
+                "cognition_invoked": True,
+                "authority_changed": False,
+            }
+        except TimeoutError:
+            raise
+        except (OSError, http.client.HTTPException) as exc:
+            raise ToolDenied(
+                "configured OpenAI cognition network request failed within exact official origin"
             ) from exc
         finally:
             api_key = None

--- a/src/grox/tools/layout_gateway.py
+++ b/src/grox/tools/layout_gateway.py
@@ -380,6 +380,8 @@ class LayoutToolGateway(ToolGateway):
                 "cognition_invoked": True,
                 "authority_changed": False,
             }
+        except ToolDenied:
+            raise
         except TimeoutError:
             raise
         except (OSError, http.client.HTTPException) as exc:

--- a/tests/integration/test_configured_openai_cognition.py
+++ b/tests/integration/test_configured_openai_cognition.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from pathlib import Path
+import json
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from grox.cognition_discovery import ConfiguredCognitionDiscovery
+from grox.configured_openai_cognition import ConfiguredOpenAICognition
+from grox.contracts import MissionMode, MissionOrder
+from grox.runtime_layout import VesselLayout
+from grox.tools.layout_gateway import LayoutToolGateway
+from grox.tools.policy import GatewayPolicy
+from grox.tools.secrets import SecretBroker
+
+
+ENDPOINT = "https://api.openai.com/v1/responses"
+ORIGIN = "https://api.openai.com"
+MODEL = "remote-model-sentinel"
+ALIAS = "openai-primary"
+INTENT = "Inspect configured cognition safely"
+CONFIG = {
+    "GROX_REASONER_PROVIDER": "openai",
+    "GROX_REASONER_MODEL": MODEL,
+    "GROX_REASONER_ENDPOINT": ENDPOINT,
+    "GROX_REASONER_CREDENTIAL_ALIAS": ALIAS,
+}
+ROSTER = [{"crew_id": "backend-engineer", "title": "Backend Engineer"}]
+
+
+class FakeResponse:
+    status = 200
+
+    def __init__(self, payload: bytes):
+        self._payload = payload
+
+    def read(self, limit: int) -> bytes:
+        return self._payload
+
+
+class FakeHTTPSConnection:
+    response_payload = b"{}"
+    request_call = None
+
+    def __init__(self, host, port, **kwargs):
+        self.host = host
+        self.port = port
+        self.closed = False
+
+    def request(self, method, path, body=None, headers=None):
+        self.__class__.request_call = (method, path, body, dict(headers or {}))
+
+    def getresponse(self):
+        return FakeResponse(self.__class__.response_payload)
+
+    def close(self):
+        self.closed = True
+
+
+class ConfiguredOpenAICognitionIntegrationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.gateway = LayoutToolGateway(
+            VesselLayout.legacy(Path(self.tempdir.name)),
+            policy=GatewayPolicy(
+                network_enabled=True,
+                allowed_origins=frozenset({ORIGIN}),
+                max_response_bytes=65536,
+            ),
+            secret_broker=SecretBroker({ALIAS: "INTEGRATION-SECRET-SENTINEL"}),
+        )
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    @staticmethod
+    def _resource():
+        return ConfiguredCognitionDiscovery(CONFIG).inventory()["resources"][0]
+
+    def _order(self) -> MissionOrder:
+        resource = self._resource()
+        return MissionOrder.new(
+            "MSN-configured-openai-cognition-integration",
+            INTENT,
+            "interpret configured cognition",
+            MissionMode.inspect,
+            "application-security-engineer",
+            allowed_actions=("cognition_invoke", "net_fetch", "secret_use"),
+            parameters={
+                "operation": "configured_openai_cognition_invoke",
+                "resource_id": resource["resource_id"],
+                "provider_kind": "openai",
+                "model": MODEL,
+                "endpoint": ENDPOINT,
+                "credential_alias": ALIAS,
+                "allowed_origins": [ORIGIN],
+                "secret_grants": [ALIAS],
+            },
+        ).seal()
+
+    def test_discovery_to_governed_structured_cognition_preserves_fitness_and_selection_boundaries(self):
+        interpretation = {
+            "commander_intent": INTENT,
+            "objective": "Inspect configured cognition",
+            "ambiguous": False,
+            "ambiguities": [],
+            "assumptions": [],
+            "information_needs": ["current runtime evidence"],
+            "candidate_crew_ids": ["backend-engineer"],
+            "options": [{
+                "name": "bounded-inspection",
+                "rationale": "Use only the authorized read path.",
+                "advantages": ["bounded"],
+                "risks": [],
+                "crew_ids": ["backend-engineer"],
+            }],
+            "recommended_option": "bounded-inspection",
+            "confidence": 0.88,
+            "proposed_mode": "inspect",
+            "proposed_risk": "low",
+        }
+        FakeHTTPSConnection.response_payload = json.dumps({
+            "id": "resp_integration",
+            "model": MODEL,
+            "output": [{
+                "type": "message",
+                "content": [{
+                    "type": "output_text",
+                    "text": json.dumps(interpretation),
+                }],
+            }],
+        }).encode()
+
+        with patch("grox.tools.layout_gateway.http.client.HTTPSConnection", FakeHTTPSConnection):
+            result = ConfiguredOpenAICognition(CONFIG, self.gateway).invoke(
+                order=self._order(),
+                roster=ROSTER,
+            )
+
+        evidence = result.evidence()
+        self.assertEqual(result.interpretation.commander_intent, INTENT)
+        self.assertEqual(result.interpretation.candidate_crew_ids, ["backend-engineer"])
+        self.assertTrue(evidence["credential_use_authorized"])
+        self.assertTrue(evidence["secret_materialized"])
+        self.assertTrue(evidence["network_invoked"])
+        self.assertTrue(evidence["cognition_invoked"])
+        self.assertTrue(evidence["cognition_succeeded"])
+        self.assertTrue(evidence["structured_interpretation_valid"])
+        self.assertTrue(evidence["ready"])
+        self.assertFalse(evidence["qualified_fit"])
+        self.assertFalse(evidence["selected"])
+        self.assertFalse(evidence["observed"])
+        self.assertFalse(evidence["mission_created"])
+        self.assertFalse(evidence["authority_changed"])
+        self.assertFalse(evidence["auto_selection"])
+        method, path, body, headers = FakeHTTPSConnection.request_call
+        self.assertEqual((method, path), ("POST", "/v1/responses"))
+        self.assertNotIn("INTEGRATION-SECRET-SENTINEL", body.decode("utf-8"))
+        self.assertEqual(headers["Authorization"], "Bearer INTEGRATION-SECRET-SENTINEL")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/mutation/run_critical_invariants.py
+++ b/tests/mutation/run_critical_invariants.py
@@ -256,6 +256,14 @@ SPECS: tuple[MutationSpec, ...] = (
         nodeid="tests/unit/test_openai_authenticated_model_probe.py::OpenAIAuthenticatedModelProbeTests::test_non_official_configured_endpoint_never_receives_credential",
     ),
     MutationSpec(
+        name="configured-openai-cognition-requires-dedicated-invoke-authority",
+        invariant="Configured OpenAI cognition must not cross the secret/network boundary without the dedicated cognition_invoke Mission grant.",
+        path="src/grox/tools/layout_gateway.py",
+        old='        self._allowed(order, "cognition_invoke")\n',
+        new='        if False:\n            self._allowed(order, "cognition_invoke")\n',
+        nodeid="tests/unit/test_openai_cognition_gateway.py::OpenAICognitionGatewayTests::test_missing_cognition_invoke_grant_fails_before_secret_or_network",
+    ),
+    MutationSpec(
         name="ci-action-immutable-pin",
         invariant="Third-party GitHub Actions must remain pinned to immutable full commit SHAs.",
         path=".github/workflows/ci.yml",

--- a/tests/unit/test_configured_openai_cognition.py
+++ b/tests/unit/test_configured_openai_cognition.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from pathlib import Path
+import json
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from grox.cognition_discovery import ConfiguredCognitionDiscovery
+from grox.configured_openai_cognition import (
+    ConfiguredOpenAICognition,
+    ConfiguredOpenAICognitionError,
+)
+from grox.contracts import MissionMode, MissionOrder
+from grox.runtime_layout import VesselLayout
+from grox.tools.layout_gateway import LayoutToolGateway
+from grox.tools.policy import GatewayPolicy
+from grox.tools.secrets import SecretBroker
+
+
+ENDPOINT = "https://api.openai.com/v1/responses"
+ORIGIN = "https://api.openai.com"
+MODEL = "remote-model-sentinel"
+ALIAS = "openai-primary"
+INTENT = "Inspect configured cognition safely"
+ROSTER = [{"crew_id": "backend-engineer", "title": "Backend Engineer"}]
+CONFIG = {
+    "GROX_REASONER_PROVIDER": "openai",
+    "GROX_REASONER_MODEL": MODEL,
+    "GROX_REASONER_ENDPOINT": ENDPOINT,
+    "GROX_REASONER_CREDENTIAL_ALIAS": ALIAS,
+}
+
+
+class ConfiguredOpenAICognitionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.gateway = LayoutToolGateway(
+            VesselLayout.legacy(Path(self.tempdir.name)),
+            policy=GatewayPolicy(
+                network_enabled=True,
+                allowed_origins=frozenset({ORIGIN}),
+            ),
+            secret_broker=SecretBroker({ALIAS: "SECRET-SENTINEL"}),
+        )
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    @staticmethod
+    def _resource(config=CONFIG):
+        return ConfiguredCognitionDiscovery(config).inventory()["resources"][0]
+
+    def _order(self, *, config=CONFIG, operation="configured_openai_cognition_invoke", seal=True):
+        resource = self._resource(config)
+        order = MissionOrder.new(
+            "MSN-configured-openai-cognition",
+            INTENT,
+            "interpret configured cognition",
+            MissionMode.inspect,
+            "application-security-engineer",
+            allowed_actions=("cognition_invoke", "net_fetch", "secret_use"),
+            parameters={
+                "operation": operation,
+                "resource_id": resource["resource_id"],
+                "provider_kind": resource["provider_kind"],
+                "model": resource["model"],
+                "endpoint": resource["endpoint"],
+                "credential_alias": ALIAS,
+                "allowed_origins": [ORIGIN],
+                "secret_grants": [ALIAS],
+            },
+        )
+        return order.seal() if seal else order
+
+    def test_exact_configured_identity_is_forwarded_and_later_states_remain_false(self):
+        payload = {
+            "id": "resp_test",
+            "model": MODEL,
+            "output_text": json.dumps({
+                "commander_intent": INTENT,
+                "objective": "Inspect configured cognition",
+                "ambiguous": False,
+                "ambiguities": [],
+                "assumptions": [],
+                "information_needs": [],
+                "candidate_crew_ids": ["backend-engineer"],
+                "options": [{
+                    "name": "inspect",
+                    "rationale": "Use bounded inspection.",
+                    "advantages": ["bounded"],
+                    "risks": [],
+                    "crew_ids": ["backend-engineer"],
+                }],
+                "recommended_option": "inspect",
+                "confidence": 0.9,
+                "proposed_mode": "inspect",
+                "proposed_risk": "low",
+            }),
+        }
+        transport = {
+            "schema": "grox-openai-responses-cognition-transport-v1",
+            "status": 200,
+            "response_id": "resp_test",
+            "response_model": MODEL,
+            "_payload": payload,
+        }
+        with patch.object(self.gateway, "openai_responses_cognition", return_value=transport) as invoke:
+            result = ConfiguredOpenAICognition(CONFIG, self.gateway).invoke(
+                order=self._order(),
+                roster=ROSTER,
+            )
+        evidence = result.evidence()
+        self.assertEqual(result.interpretation.commander_intent, INTENT)
+        self.assertEqual(result.interpretation.recommended_option, "inspect")
+        self.assertTrue(evidence["cognition_succeeded"])
+        self.assertTrue(evidence["ready"])
+        self.assertFalse(evidence["qualified_fit"])
+        self.assertFalse(evidence["selected"])
+        self.assertFalse(evidence["observed"])
+        self.assertFalse(evidence["authority_changed"])
+        self.assertNotIn("_payload", repr(evidence))
+        kwargs = invoke.call_args.kwargs
+        self.assertEqual(kwargs["directive"], INTENT)
+        self.assertEqual(kwargs["resource_id"], self._resource()["resource_id"])
+        self.assertEqual(kwargs["credential_alias"], ALIAS)
+
+    def test_nonofficial_configuration_fails_before_gateway(self):
+        config = {
+            **CONFIG,
+            "GROX_REASONER_ENDPOINT": "https://compatible.example/v1/responses",
+        }
+        with patch.object(
+            self.gateway,
+            "openai_responses_cognition",
+            side_effect=AssertionError("nonofficial config must fail before gateway"),
+        ) as invoke:
+            with self.assertRaisesRegex(ConfiguredOpenAICognitionError, "official Responses endpoint"):
+                ConfiguredOpenAICognition(config, self.gateway).invoke(
+                    order=self._order(config=config),
+                    roster=ROSTER,
+                )
+        invoke.assert_not_called()
+
+    def test_unsealed_or_wrong_operation_fails_before_gateway(self):
+        cognition = ConfiguredOpenAICognition(CONFIG, self.gateway)
+        with patch.object(self.gateway, "openai_responses_cognition") as invoke:
+            with self.assertRaises(ConfiguredOpenAICognitionError):
+                cognition.invoke(order=self._order(seal=False), roster=ROSTER)
+            with self.assertRaisesRegex(ConfiguredOpenAICognitionError, "operation_mismatch"):
+                cognition.invoke(
+                    order=self._order(operation="configured_openai_authenticated_model_probe"),
+                    roster=ROSTER,
+                )
+        invoke.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_configured_openai_cognition.py
+++ b/tests/unit/test_configured_openai_cognition.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-import json
 import tempfile
 import unittest
 from unittest.mock import patch
@@ -12,6 +11,7 @@ from grox.configured_openai_cognition import (
     ConfiguredOpenAICognitionError,
 )
 from grox.contracts import MissionMode, MissionOrder
+from grox.reasoning.contracts import MissionInterpretation
 from grox.runtime_layout import VesselLayout
 from grox.tools.layout_gateway import LayoutToolGateway
 from grox.tools.policy import GatewayPolicy
@@ -73,11 +73,10 @@ class ConfiguredOpenAICognitionTests(unittest.TestCase):
         )
         return order.seal() if seal else order
 
-    def test_exact_configured_identity_is_forwarded_and_later_states_remain_false(self):
-        payload = {
-            "id": "resp_test",
-            "model": MODEL,
-            "output_text": json.dumps({
+    @staticmethod
+    def _interpretation() -> MissionInterpretation:
+        return MissionInterpretation.from_mapping(
+            {
                 "commander_intent": INTENT,
                 "objective": "Inspect configured cognition",
                 "ambiguous": False,
@@ -96,14 +95,18 @@ class ConfiguredOpenAICognitionTests(unittest.TestCase):
                 "confidence": 0.9,
                 "proposed_mode": "inspect",
                 "proposed_risk": "low",
-            }),
-        }
+            },
+            expected_intent=INTENT,
+        )
+
+    def test_exact_configured_identity_is_forwarded_and_later_states_remain_false(self):
         transport = {
             "schema": "grox-openai-responses-cognition-transport-v1",
             "status": 200,
             "response_id": "resp_test",
             "response_model": MODEL,
-            "_payload": payload,
+            "interpretation": self._interpretation(),
+            "raw_response_returned": False,
         }
         with patch.object(self.gateway, "openai_responses_cognition", return_value=transport) as invoke:
             result = ConfiguredOpenAICognition(CONFIG, self.gateway).invoke(
@@ -119,7 +122,8 @@ class ConfiguredOpenAICognitionTests(unittest.TestCase):
         self.assertFalse(evidence["selected"])
         self.assertFalse(evidence["observed"])
         self.assertFalse(evidence["authority_changed"])
-        self.assertNotIn("_payload", repr(evidence))
+        self.assertTrue(evidence["raw_response_returned"] is False)
+        self.assertNotIn("_payload", repr(transport))
         kwargs = invoke.call_args.kwargs
         self.assertEqual(kwargs["directive"], INTENT)
         self.assertEqual(kwargs["resource_id"], self._resource()["resource_id"])

--- a/tests/unit/test_openai_cognition_gateway.py
+++ b/tests/unit/test_openai_cognition_gateway.py
@@ -149,6 +149,7 @@ class OpenAICognitionGatewayTests(unittest.TestCase):
         return json.dumps({
             "id": "resp_test",
             "model": MODEL,
+            "provider_extra": "RAW-PROVIDER-SENTINEL",
             "output_text": json.dumps(interpretation),
         }).encode()
 
@@ -174,7 +175,11 @@ class OpenAICognitionGatewayTests(unittest.TestCase):
         self.assertEqual(result["status"], 200)
         self.assertEqual(result["response_id"], "resp_test")
         self.assertEqual(result["response_model"], MODEL)
+        self.assertEqual(result["interpretation"].commander_intent, INTENT)
         self.assertTrue(result["cognition_invoked"])
+        self.assertFalse(result["raw_response_returned"])
+        self.assertNotIn("_payload", result)
+        self.assertNotIn("RAW-PROVIDER-SENTINEL", repr(result))
         self.assertNotIn(secret, repr(result))
         self.assertEqual(
             broker.materialize_calls,
@@ -228,7 +233,7 @@ class OpenAICognitionGatewayTests(unittest.TestCase):
             )
         self.assertEqual(broker.materialize_calls, [])
 
-    def test_non_200_and_invalid_json_are_sanitized_failures(self):
+    def test_non_200_invalid_json_and_invalid_structure_are_sanitized_failures(self):
         gateway, _ = self._gateway({ALIAS: "SECRET-SENTINEL"})
         FakeHTTPSConnection.response = FakeResponse(
             429,
@@ -243,6 +248,14 @@ class OpenAICognitionGatewayTests(unittest.TestCase):
         FakeHTTPSConnection.response = FakeResponse(200, b"{not-json")
         with patch("grox.tools.layout_gateway.http.client.HTTPSConnection", FakeHTTPSConnection):
             with self.assertRaisesRegex(ToolDenied, "invalid JSON"):
+                self._invoke(gateway, self._order())
+
+        FakeHTTPSConnection.response = FakeResponse(
+            200,
+            json.dumps({"output_text": "{not-valid-structured-output"}).encode(),
+        )
+        with patch("grox.tools.layout_gateway.http.client.HTTPSConnection", FakeHTTPSConnection):
+            with self.assertRaisesRegex(ToolDenied, "invalid structured interpretation"):
                 self._invoke(gateway, self._order())
 
 

--- a/tests/unit/test_openai_cognition_gateway.py
+++ b/tests/unit/test_openai_cognition_gateway.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+from pathlib import Path
+import json
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from grox.cognition_discovery import ConfiguredCognitionDiscovery
+from grox.contracts import MissionMode, MissionOrder
+from grox.runtime_layout import VesselLayout
+from grox.tools.gateway import ToolDenied
+from grox.tools.layout_gateway import LayoutToolGateway
+from grox.tools.policy import GatewayPolicy
+from grox.tools.secrets import SecretBroker
+
+
+ENDPOINT = "https://api.openai.com/v1/responses"
+ORIGIN = "https://api.openai.com"
+MODEL = "remote-model-sentinel"
+ALIAS = "openai-primary"
+INTENT = "Inspect configured cognition safely"
+ROSTER = [{"crew_id": "backend-engineer", "title": "Backend Engineer"}]
+CONFIG = {
+    "GROX_REASONER_PROVIDER": "openai",
+    "GROX_REASONER_MODEL": MODEL,
+    "GROX_REASONER_ENDPOINT": ENDPOINT,
+    "GROX_REASONER_CREDENTIAL_ALIAS": ALIAS,
+}
+
+
+class TrackingSecretBroker(SecretBroker):
+    def __init__(self, secrets=None):
+        super().__init__(secrets)
+        self.materialize_calls: list[dict[str, str]] = []
+
+    def materialize_env(self, order, requested):
+        self.materialize_calls.append(dict(requested or {}))
+        return super().materialize_env(order, requested)
+
+
+class FakeResponse:
+    def __init__(self, status: int, payload: bytes):
+        self.status = status
+        self._payload = payload
+
+    def read(self, limit: int) -> bytes:
+        return self._payload
+
+
+class FakeHTTPSConnection:
+    response = FakeResponse(500, b"{}")
+    instances: list["FakeHTTPSConnection"] = []
+
+    def __init__(self, host, port, **kwargs):
+        self.host = host
+        self.port = port
+        self.kwargs = kwargs
+        self.request_call = None
+        self.closed = False
+        self.__class__.instances.append(self)
+
+    def request(self, method, path, body=None, headers=None):
+        self.request_call = (method, path, body, dict(headers or {}))
+
+    def getresponse(self):
+        return self.__class__.response
+
+    def close(self):
+        self.closed = True
+
+
+class OpenAICognitionGatewayTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        FakeHTTPSConnection.instances = []
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    @staticmethod
+    def _resource() -> dict:
+        return ConfiguredCognitionDiscovery(CONFIG).inventory()["resources"][0]
+
+    def _gateway(self, secrets=None):
+        broker = TrackingSecretBroker(secrets)
+        gateway = LayoutToolGateway(
+            VesselLayout.legacy(Path(self.tempdir.name)),
+            policy=GatewayPolicy(
+                network_enabled=True,
+                allowed_origins=frozenset({ORIGIN}),
+                max_response_bytes=65536,
+            ),
+            secret_broker=broker,
+        )
+        return gateway, broker
+
+    def _order(
+        self,
+        *,
+        allowed_actions=("cognition_invoke", "net_fetch", "secret_use"),
+        endpoint=ENDPOINT,
+        secret_grants=(ALIAS,),
+        seal=True,
+    ) -> MissionOrder:
+        resource = self._resource()
+        order = MissionOrder.new(
+            "MSN-openai-cognition",
+            INTENT,
+            "interpret configured cognition",
+            MissionMode.inspect,
+            "application-security-engineer",
+            allowed_actions=allowed_actions,
+            parameters={
+                "operation": "configured_openai_cognition_invoke",
+                "resource_id": resource["resource_id"],
+                "provider_kind": "openai",
+                "model": MODEL,
+                "endpoint": endpoint,
+                "credential_alias": ALIAS,
+                "allowed_origins": [ORIGIN],
+                "secret_grants": list(secret_grants),
+            },
+        )
+        return order.seal() if seal else order
+
+    @staticmethod
+    def _valid_payload() -> bytes:
+        interpretation = {
+            "commander_intent": INTENT,
+            "objective": "Inspect configured cognition",
+            "ambiguous": False,
+            "ambiguities": [],
+            "assumptions": [],
+            "information_needs": [],
+            "candidate_crew_ids": ["backend-engineer"],
+            "options": [{
+                "name": "inspect",
+                "rationale": "Use bounded inspection.",
+                "advantages": ["bounded"],
+                "risks": [],
+                "crew_ids": ["backend-engineer"],
+            }],
+            "recommended_option": "inspect",
+            "confidence": 0.9,
+            "proposed_mode": "inspect",
+            "proposed_risk": "low",
+        }
+        return json.dumps({
+            "id": "resp_test",
+            "model": MODEL,
+            "output_text": json.dumps(interpretation),
+        }).encode()
+
+    def _invoke(self, gateway, order, **overrides):
+        return gateway.openai_responses_cognition(
+            order,
+            resource_id=overrides.get("resource_id", self._resource()["resource_id"]),
+            responses_endpoint=overrides.get("responses_endpoint", ENDPOINT),
+            model=overrides.get("model", MODEL),
+            credential_alias=overrides.get("credential_alias", ALIAS),
+            directive=overrides.get("directive", INTENT),
+            roster=overrides.get("roster", ROSTER),
+        )
+
+    def test_exact_sealed_cognition_posts_only_to_official_responses_and_hides_secret(self):
+        secret = "OPENAI-COGNITION-SECRET-SENTINEL"
+        FakeHTTPSConnection.response = FakeResponse(200, self._valid_payload())
+        gateway, broker = self._gateway({ALIAS: secret})
+
+        with patch("grox.tools.layout_gateway.http.client.HTTPSConnection", FakeHTTPSConnection):
+            result = self._invoke(gateway, self._order())
+
+        self.assertEqual(result["status"], 200)
+        self.assertEqual(result["response_id"], "resp_test")
+        self.assertEqual(result["response_model"], MODEL)
+        self.assertTrue(result["cognition_invoked"])
+        self.assertNotIn(secret, repr(result))
+        self.assertEqual(
+            broker.materialize_calls,
+            [{"GROX_OPENAI_COGNITION_CREDENTIAL": ALIAS}],
+        )
+        self.assertEqual(len(FakeHTTPSConnection.instances), 1)
+        conn = FakeHTTPSConnection.instances[0]
+        method, path, body, headers = conn.request_call
+        self.assertEqual((conn.host, conn.port), ("api.openai.com", 443))
+        self.assertEqual(method, "POST")
+        self.assertEqual(path, "/v1/responses")
+        self.assertEqual(headers["Authorization"], f"Bearer {secret}")
+        request_body = json.loads(body.decode("utf-8"))
+        self.assertEqual(request_body["model"], MODEL)
+        self.assertFalse(request_body["store"])
+        self.assertNotIn("tools", request_body)
+        self.assertIn(INTENT, request_body["input"])
+        self.assertTrue(conn.closed)
+
+    def test_missing_cognition_invoke_grant_fails_before_secret_or_network(self):
+        gateway, broker = self._gateway({ALIAS: "SECRET-SENTINEL"})
+        order = self._order(allowed_actions=("net_fetch", "secret_use"))
+        with patch(
+            "grox.tools.layout_gateway.http.client.HTTPSConnection",
+            side_effect=AssertionError("missing cognition grant must fail before network"),
+        ) as connection_mock:
+            with self.assertRaisesRegex(ToolDenied, "cognition_invoke"):
+                self._invoke(gateway, order)
+        self.assertEqual(broker.materialize_calls, [])
+        connection_mock.assert_not_called()
+
+    def test_unsealed_order_fails_without_becoming_sealed(self):
+        gateway, broker = self._gateway({ALIAS: "SECRET-SENTINEL"})
+        order = self._order(seal=False)
+        with self.assertRaisesRegex(ToolDenied, "already sealed"):
+            self._invoke(gateway, order)
+        self.assertFalse(order.sealed)
+        self.assertEqual(broker.materialize_calls, [])
+
+    def test_directive_mismatch_and_nonofficial_endpoint_fail_before_materialization(self):
+        gateway, broker = self._gateway({ALIAS: "SECRET-SENTINEL"})
+        with self.assertRaisesRegex(ToolDenied, "Commander intent mismatch"):
+            self._invoke(gateway, self._order(), directive="different")
+        self.assertEqual(broker.materialize_calls, [])
+
+        with self.assertRaisesRegex(ToolDenied, "official Responses endpoint"):
+            self._invoke(
+                gateway,
+                self._order(endpoint="https://compatible.example/v1/responses"),
+                responses_endpoint="https://compatible.example/v1/responses",
+            )
+        self.assertEqual(broker.materialize_calls, [])
+
+    def test_non_200_and_invalid_json_are_sanitized_failures(self):
+        gateway, _ = self._gateway({ALIAS: "SECRET-SENTINEL"})
+        FakeHTTPSConnection.response = FakeResponse(
+            429,
+            b'{"error":{"message":"provider-secret-detail"}}',
+        )
+        with patch("grox.tools.layout_gateway.http.client.HTTPSConnection", FakeHTTPSConnection):
+            with self.assertRaises(ToolDenied) as caught:
+                self._invoke(gateway, self._order())
+        self.assertIn("HTTP 429", str(caught.exception))
+        self.assertNotIn("provider-secret-detail", str(caught.exception))
+
+        FakeHTTPSConnection.response = FakeResponse(200, b"{not-json")
+        with patch("grox.tools.layout_gateway.http.client.HTTPSConnection", FakeHTTPSConnection):
+            with self.assertRaisesRegex(ToolDenied, "invalid JSON"):
+                self._invoke(gateway, self._order())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #172
Parent: #115

Development-first runtime slice from canonical `main@1d7863f58a3cddc947190d98f72a8b5ac253cfde`.

This qualifies one bounded configured official OpenAI cognition invocation path through the Tool Gateway.

Qualified boundary:
- dedicated `cognition_invoke` authority is required in addition to `net_fetch` and `secret_use`;
- exact already-sealed Mission Order binds Commander intent plus configured resource/provider/model/endpoint/credential alias;
- gateway builds the structured Responses request internally rather than accepting arbitrary authenticated request bodies;
- exact official `https://api.openai.com/v1/responses` only;
- exact credential alias is materialized only inside the gateway request boundary;
- one bounded POST `/v1/responses`; no arbitrary URL or OpenAI tool declaration surface;
- response/error sizes are bounded and provider error bodies are not surfaced;
- raw provider payload does not escape the gateway;
- `MissionInterpretation` validates structured output and exact Commander-intent preservation;
- successful invocation proves this exact cognition call succeeded and is ready, while `qualified_fit`, `selected`, and `observed` remain false;
- no Mission creation, fallback/routing, adaptive selection, authority widening, release/NCI/Apex/A8 advancement.

Final exact head: `74247231a4817d14ed818c44c1d0b07e8738910e`
Synthetic merge: `55e20386ab9a95f0cab954f52fb86f29188fa47a`
Synthetic merge tree: `75d13da5d8fa46b0692646508627e3533b9f2c96`
CI #581 / run `32959889192`: PASS across Wheel + Python 3.11-3.14.
Python 3.12: 460 pytest passed, 2 skipped, 505 subtests; 462 unittest tests OK, 2 skipped; Vessel Health 10 PASS / 0 WARN / 0 FAIL / 0 UNKNOWN; critical mutation matrix 28/28 KILLED with zero survivors and clean exact restoration; health 7/7; reconstitution 9/9; operational drift 4/4; source provenance 6/6; Post-Apex integrated qualification PASS.

Permanent critical mutation added: `configured-openai-cognition-requires-dedicated-invoke-authority`.