### PR TITLE
Qualify exact configured cognition route attempt-performance evidence

### DIFF
--- a/src/grox/configured_cognition_attempt_performance.py
+++ b/src/grox/configured_cognition_attempt_performance.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+class ConfiguredCognitionAttemptPerformanceError(ValueError):
+    """Attempt-performance evidence is malformed or internally inconsistent."""
+
+
+@dataclass(frozen=True, slots=True)
+class ConfiguredCognitionAttemptPerformance:
+    """Privacy-minimized exact identity and outcome for one actual provider attempt."""
+
+    resource_id: str
+    provider_kind: str
+    model: str
+    endpoint: str
+    credential_alias: str
+    mission_id: str
+    order_id: str
+    selection_id: str
+    placement: str
+    outcome: str
+    observation_id: str | None = None
+
+    _OUTCOMES = frozenset({"success", "provider_timeout"})
+
+    def __post_init__(self) -> None:
+        for name in (
+            "resource_id",
+            "provider_kind",
+            "model",
+            "endpoint",
+            "credential_alias",
+            "mission_id",
+            "order_id",
+            "selection_id",
+            "placement",
+            "outcome",
+        ):
+            value = getattr(self, name)
+            if not isinstance(value, str) or not value.strip():
+                raise ConfiguredCognitionAttemptPerformanceError(f"{name} must be a non-empty string")
+            object.__setattr__(self, name, value.strip())
+        if self.outcome not in self._OUTCOMES:
+            raise ConfiguredCognitionAttemptPerformanceError(
+                f"unsupported configured cognition attempt outcome: {self.outcome}"
+            )
+        if self.outcome == "success":
+            if not isinstance(self.observation_id, str) or not self.observation_id.strip():
+                raise ConfiguredCognitionAttemptPerformanceError(
+                    "successful attempt performance requires an observation_id"
+                )
+            object.__setattr__(self, "observation_id", self.observation_id.strip())
+        elif self.observation_id is not None:
+            raise ConfiguredCognitionAttemptPerformanceError(
+                "provider timeout performance must not carry an observation_id"
+            )
+
+    @property
+    def succeeded(self) -> bool:
+        return self.outcome == "success"
+
+    @property
+    def timed_out(self) -> bool:
+        return self.outcome == "provider_timeout"
+
+    def evidence(self) -> dict[str, Any]:
+        return {
+            "schema": "grox-configured-cognition-attempt-performance-v1",
+            "resource_id": self.resource_id,
+            "provider_kind": self.provider_kind,
+            "model": self.model,
+            "endpoint": self.endpoint,
+            "credential_alias": self.credential_alias,
+            "mission_id": self.mission_id,
+            "order_id": self.order_id,
+            "selection_id": self.selection_id,
+            "placement": self.placement,
+            "outcome": self.outcome,
+            "observation_id": self.observation_id,
+            "actual_provider_attempt": True,
+            "provider_succeeded": self.succeeded,
+            "provider_timed_out": self.timed_out,
+            "raw_response_returned": False,
+            "credential_material_returned": False,
+            "secret_value_returned": False,
+            "ranking_applied": False,
+            "learning_applied": False,
+            "candidate_expansion": False,
+            "authority_changed": False,
+        }

--- a/src/grox/configured_cognition_fallback.py
+++ b/src/grox/configured_cognition_fallback.py
@@ -6,6 +6,7 @@ from types import MappingProxyType
 from typing import Any
 
 from .configured_cognition_attempt import ConfiguredCognitionAttempt
+from .configured_cognition_attempt_performance import ConfiguredCognitionAttemptPerformance
 from .configured_cognition_fitness import (
     ConfiguredCognitionFitnessResult,
     ConfiguredCognitionMissionFitness,
@@ -102,6 +103,7 @@ class ConfiguredCognitionFallbackResult:
     candidate_order: tuple[str, ...]
     attempted_resource_ids: tuple[str, ...]
     timed_out_resource_ids: tuple[str, ...]
+    attempt_performance: tuple[ConfiguredCognitionAttemptPerformance, ...]
     executed: SelectedConfiguredCognitionResult
 
     @property
@@ -118,6 +120,7 @@ class ConfiguredCognitionFallbackResult:
             "candidate_order": list(self.candidate_order),
             "attempted_resource_ids": list(self.attempted_resource_ids),
             "timed_out_resource_ids": list(self.timed_out_resource_ids),
+            "attempt_performance": [item.evidence() for item in self.attempt_performance],
             "executed_resource_id": self.executed.resource_id,
             "executed_observation_id": self.executed.observation_id,
             "mission_id": self.executed.mission_id,
@@ -248,12 +251,36 @@ class ConfiguredCognitionFallback:
             and isinstance(cognition_error.__cause__, TimeoutError)
         )
 
+    @staticmethod
+    def _attempt_performance(
+        candidate: ConfiguredCognitionFallbackCandidate,
+        *,
+        selection_id: str,
+        outcome: str,
+        observation_id: str | None = None,
+    ) -> ConfiguredCognitionAttemptPerformance:
+        qualification = candidate.qualification
+        return ConfiguredCognitionAttemptPerformance(
+            resource_id=qualification.resource_id,
+            provider_kind=qualification.provider_kind,
+            model=qualification.model,
+            endpoint=qualification.endpoint,
+            credential_alias=qualification.credential_alias,
+            mission_id=candidate.order.mission_id,
+            order_id=candidate.order.order_id,
+            selection_id=selection_id,
+            placement=candidate.fitness.placement,
+            outcome=outcome,
+            observation_id=observation_id,
+        )
+
     def invoke(self, *, roster: list[dict[str, Any]]) -> ConfiguredCognitionFallbackResult:
         if not isinstance(roster, list) or not all(isinstance(item, dict) for item in roster):
             raise TypeError("roster must be a list of mappings")
 
         attempted: list[str] = []
         timed_out: list[str] = []
+        performance: list[ConfiguredCognitionAttemptPerformance] = []
         for index, resource_id in enumerate(self._policy.candidate_order):
             candidate = self._candidates[resource_id]
 
@@ -289,16 +316,32 @@ class ConfiguredCognitionFallback:
                         f"fallback stopped on non-recoverable candidate failure: {resource_id}"
                     ) from exc
                 timed_out.append(resource_id)
+                performance.append(
+                    self._attempt_performance(
+                        candidate,
+                        selection_id=selection.selection_id,
+                        outcome="provider_timeout",
+                    )
+                )
                 if index + 1 >= len(self._policy.candidate_order):
                     raise ConfiguredCognitionFallbackError(
                         "explicit configured cognition fallback envelope exhausted on provider timeouts"
                     ) from exc
                 continue
 
+            performance.append(
+                self._attempt_performance(
+                    candidate,
+                    selection_id=selection.selection_id,
+                    outcome="success",
+                    observation_id=executed.observation_id,
+                )
+            )
             return ConfiguredCognitionFallbackResult(
                 candidate_order=self._policy.candidate_order,
                 attempted_resource_ids=tuple(attempted),
                 timed_out_resource_ids=tuple(timed_out),
+                attempt_performance=tuple(performance),
                 executed=executed,
             )
 

--- a/src/grox/configured_cognition_route_execution.py
+++ b/src/grox/configured_cognition_route_execution.py
@@ -7,6 +7,7 @@ from types import MappingProxyType
 from typing import Any
 
 from .configured_cognition_attempt import ConfiguredCognitionAttempt
+from .configured_cognition_attempt_performance import ConfiguredCognitionAttemptPerformance
 from .configured_cognition_fallback import (
     ConfiguredCognitionFallback,
     ConfiguredCognitionFallbackCandidate,
@@ -51,6 +52,7 @@ class ConfiguredCognitionRouteExecutionResult:
     attempted_resource_ids: tuple[str, ...]
     timed_out_resource_ids: tuple[str, ...]
     attempt_readiness_age_seconds: Mapping[str, float]
+    attempt_performance: tuple[ConfiguredCognitionAttemptPerformance, ...]
     executed: SelectedConfiguredCognitionResult
 
     @property
@@ -68,6 +70,7 @@ class ConfiguredCognitionRouteExecutionResult:
             "attempted_resource_ids": list(self.attempted_resource_ids),
             "timed_out_resource_ids": list(self.timed_out_resource_ids),
             "attempt_readiness_age_seconds": dict(self.attempt_readiness_age_seconds),
+            "attempt_performance": [item.evidence() for item in self.attempt_performance],
             "executed_resource_id": self.executed.resource_id,
             "executed_observation_id": self.executed.observation_id,
             "mission_id": self.executed.mission_id,
@@ -255,11 +258,25 @@ class ConfiguredCognitionRouteExecution:
                 resource_id=candidate.resource_id,
                 reason="selected_invocation_failed",
             ) from exc
+        performance = ConfiguredCognitionAttemptPerformance(
+            resource_id=candidate.qualification.resource_id,
+            provider_kind=candidate.qualification.provider_kind,
+            model=candidate.qualification.model,
+            endpoint=candidate.qualification.endpoint,
+            credential_alias=candidate.qualification.credential_alias,
+            mission_id=candidate.order.mission_id,
+            order_id=candidate.order.order_id,
+            selection_id=selection.selection_id,
+            placement=candidate.fitness.placement,
+            outcome="success",
+            observation_id=executed.observation_id,
+        )
         return ConfiguredCognitionRouteExecutionResult(
             candidate_order=(candidate.resource_id,),
             attempted_resource_ids=(candidate.resource_id,),
             timed_out_resource_ids=(),
             attempt_readiness_age_seconds=MappingProxyType(dict(self._attempt_ages)),
+            attempt_performance=(performance,),
             executed=executed,
         )
 
@@ -301,5 +318,6 @@ class ConfiguredCognitionRouteExecution:
             attempted_resource_ids=result.attempted_resource_ids,
             timed_out_resource_ids=result.timed_out_resource_ids,
             attempt_readiness_age_seconds=MappingProxyType(dict(self._attempt_ages)),
+            attempt_performance=result.attempt_performance,
             executed=result.executed,
         )

--- a/tests/integration/test_configured_cognition_fallback.py
+++ b/tests/integration/test_configured_cognition_fallback.py
@@ -200,6 +200,17 @@ class ConfiguredCognitionFallbackIntegrationTests(unittest.TestCase):
             self.assertEqual(report.executed.order_id, order_b.order_id)
             self.assertEqual(report.executed.response_id, "resp-fallback-execution")
             self.assertEqual(report.interpretation.commander_intent, INTENT)
+            self.assertEqual([item.outcome for item in report.attempt_performance], ["provider_timeout", "success"])
+            self.assertEqual(report.attempt_performance[0].resource_id, candidate_a.resource_id)
+            self.assertEqual(report.attempt_performance[0].model, MODEL_A)
+            self.assertEqual(report.attempt_performance[0].credential_alias, ALIAS_A)
+            self.assertEqual(report.attempt_performance[0].order_id, order_a.order_id)
+            self.assertIsNone(report.attempt_performance[0].observation_id)
+            self.assertEqual(report.attempt_performance[1].resource_id, candidate_b.resource_id)
+            self.assertEqual(report.attempt_performance[1].model, MODEL_B)
+            self.assertEqual(report.attempt_performance[1].credential_alias, ALIAS_B)
+            self.assertEqual(report.attempt_performance[1].order_id, order_b.order_id)
+            self.assertEqual(report.attempt_performance[1].observation_id, report.executed.observation_id)
             self.assertEqual(len(observed), 1)
             observed_identity = observed[0]["identity"]
             self.assertEqual(observed_identity["resource_id"], candidate_b.resource_id)
@@ -221,6 +232,14 @@ class ConfiguredCognitionFallbackIntegrationTests(unittest.TestCase):
             self.assertFalse(evidence["raw_response_returned"])
             self.assertFalse(evidence["mission_created"])
             self.assertFalse(evidence["authority_changed"])
+            self.assertEqual(
+                [item["outcome"] for item in evidence["attempt_performance"]],
+                ["provider_timeout", "success"],
+            )
+            self.assertNotIn("SECRET-A", repr(evidence))
+            self.assertNotIn("SECRET-B", repr(evidence))
+            self.assertFalse(any(item["ranking_applied"] for item in evidence["attempt_performance"]))
+            self.assertFalse(any(item["learning_applied"] for item in evidence["attempt_performance"]))
 
 
 if __name__ == "__main__":

--- a/tests/mutation/run_critical_invariants.py
+++ b/tests/mutation/run_critical_invariants.py
@@ -328,6 +328,14 @@ SPECS: tuple[MutationSpec, ...] = (
         nodeid="tests/unit/test_configured_cognition_route_execution.py::ConfiguredCognitionRouteExecutionTests::test_fallback_is_revalidated_after_primary_timeout_and_stale_fallback_stops",
     ),
     MutationSpec(
+        name="configured-cognition-attempt-performance-exact-credential-alias",
+        invariant="Configured cognition attempt-performance evidence must preserve the exact credential alias of the actual attempted candidate.",
+        path="src/grox/configured_cognition_fallback.py",
+        old='            credential_alias=qualification.credential_alias,\n',
+        new='            credential_alias="mutated-alias",\n',
+        nodeid="tests/unit/test_configured_cognition_route_execution.py::ConfiguredCognitionRouteExecutionTests::test_timeout_advances_only_to_fallback_that_is_fresh_at_its_own_attempt",
+    ),
+    MutationSpec(
         name="ci-action-immutable-pin",
         invariant="Third-party GitHub Actions must remain pinned to immutable full commit SHAs.",
         path=".github/workflows/ci.yml",

--- a/tests/unit/test_configured_cognition_attempt_performance.py
+++ b/tests/unit/test_configured_cognition_attempt_performance.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import unittest
+
+from grox.configured_cognition_attempt_performance import (
+    ConfiguredCognitionAttemptPerformance,
+    ConfiguredCognitionAttemptPerformanceError,
+)
+
+
+class ConfiguredCognitionAttemptPerformanceTests(unittest.TestCase):
+    def test_success_evidence_is_exact_privacy_minimized_and_non_authoritative(self):
+        item = ConfiguredCognitionAttemptPerformance(
+            resource_id="cognition:configured:openai:abc123",
+            provider_kind="openai",
+            model="model-a",
+            endpoint="https://api.openai.com/v1/responses",
+            credential_alias="alias-a",
+            mission_id="MSN-1",
+            order_id="ORD-1",
+            selection_id="SEL-1",
+            placement="mission_interpretation",
+            outcome="success",
+            observation_id="OBS-1",
+        )
+
+        evidence = item.evidence()
+        self.assertTrue(item.succeeded)
+        self.assertFalse(item.timed_out)
+        self.assertEqual(evidence["credential_alias"], "alias-a")
+        self.assertEqual(evidence["outcome"], "success")
+        self.assertEqual(evidence["observation_id"], "OBS-1")
+        self.assertTrue(evidence["actual_provider_attempt"])
+        self.assertFalse(evidence["ranking_applied"])
+        self.assertFalse(evidence["learning_applied"])
+        self.assertFalse(evidence["authority_changed"])
+        self.assertFalse(evidence["credential_material_returned"])
+        self.assertFalse(evidence["secret_value_returned"])
+
+    def test_timeout_requires_no_observation_and_preserves_exact_selection_identity(self):
+        item = ConfiguredCognitionAttemptPerformance(
+            resource_id="cognition:configured:openai:def456",
+            provider_kind="openai",
+            model="model-b",
+            endpoint="https://api.openai.com/v1/responses",
+            credential_alias="alias-b",
+            mission_id="MSN-1",
+            order_id="ORD-2",
+            selection_id="SEL-2",
+            placement="mission_interpretation",
+            outcome="provider_timeout",
+        )
+
+        self.assertFalse(item.succeeded)
+        self.assertTrue(item.timed_out)
+        self.assertIsNone(item.observation_id)
+        self.assertEqual(item.selection_id, "SEL-2")
+
+    def test_malformed_outcome_or_observation_semantics_fail_closed(self):
+        kwargs = {
+            "resource_id": "cognition:configured:openai:def456",
+            "provider_kind": "openai",
+            "model": "model-b",
+            "endpoint": "https://api.openai.com/v1/responses",
+            "credential_alias": "alias-b",
+            "mission_id": "MSN-1",
+            "order_id": "ORD-2",
+            "selection_id": "SEL-2",
+            "placement": "mission_interpretation",
+        }
+        with self.assertRaises(ConfiguredCognitionAttemptPerformanceError):
+            ConfiguredCognitionAttemptPerformance(**kwargs, outcome="unknown")
+        with self.assertRaises(ConfiguredCognitionAttemptPerformanceError):
+            ConfiguredCognitionAttemptPerformance(**kwargs, outcome="success")
+        with self.assertRaises(ConfiguredCognitionAttemptPerformanceError):
+            ConfiguredCognitionAttemptPerformance(
+                **kwargs,
+                outcome="provider_timeout",
+                observation_id="OBS-not-allowed",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_configured_cognition_route_execution.py
+++ b/tests/unit/test_configured_cognition_route_execution.py
@@ -317,6 +317,14 @@ class ConfiguredCognitionRouteExecutionTests(unittest.TestCase):
         self.assertEqual(result.executed.resource_id, fallback.resource_id)
         self.assertEqual(result.attempt_readiness_age_seconds[primary.resource_id], 20.0)
         self.assertEqual(result.attempt_readiness_age_seconds[fallback.resource_id], 30.0)
+        self.assertEqual([item.outcome for item in result.attempt_performance], ["provider_timeout", "success"])
+        self.assertEqual(result.attempt_performance[0].resource_id, primary.resource_id)
+        self.assertEqual(result.attempt_performance[0].credential_alias, "alias-primary")
+        self.assertEqual(result.attempt_performance[0].order_id, primary.order.order_id)
+        self.assertEqual(result.attempt_performance[1].resource_id, fallback.resource_id)
+        self.assertEqual(result.attempt_performance[1].credential_alias, "alias-fallback")
+        self.assertEqual(result.attempt_performance[1].order_id, fallback.order.order_id)
+        self.assertEqual(result.attempt_performance[1].observation_id, result.executed.observation_id)
         evidence = result.evidence()
         self.assertTrue(evidence["fresh_readiness_revalidated_per_attempt"])
         self.assertTrue(evidence["ready_at_plan_time_not_sufficient"])
@@ -324,6 +332,13 @@ class ConfiguredCognitionRouteExecutionTests(unittest.TestCase):
         self.assertFalse(evidence["candidate_expansion"])
         self.assertFalse(evidence["adaptive_routing_enabled"])
         self.assertFalse(evidence["authority_changed"])
+        self.assertEqual(
+            [item["outcome"] for item in evidence["attempt_performance"]],
+            ["provider_timeout", "success"],
+        )
+        self.assertFalse(any(item["ranking_applied"] for item in evidence["attempt_performance"]))
+        self.assertFalse(any(item["learning_applied"] for item in evidence["attempt_performance"]))
+        self.assertNotIn("SECRET-", repr(evidence))
 
     def test_single_candidate_route_uses_same_shared_attempt_seam(self):
         primary = self._candidate("model-primary", "alias-primary")
@@ -358,6 +373,10 @@ class ConfiguredCognitionRouteExecutionTests(unittest.TestCase):
         self.assertEqual(result.attempted_resource_ids, (primary.resource_id,))
         self.assertEqual(result.timed_out_resource_ids, ())
         self.assertFalse(result.switched)
+        self.assertEqual(len(result.attempt_performance), 1)
+        self.assertEqual(result.attempt_performance[0].outcome, "success")
+        self.assertEqual(result.attempt_performance[0].resource_id, primary.resource_id)
+        self.assertEqual(result.attempt_performance[0].credential_alias, "alias-primary")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #195
Parent: #115

Development-first runtime slice from canonical `main@60cf8b181e52136b1b76a4d60551a0d479a03dab`.

Boundary:
- records one immutable privacy-minimized performance fact only after an actual configured-provider attempt;
- binds each fact to exact resource ID, provider, model, endpoint, credential alias, Mission, Order, selection and placement;
- records only `success` or the already-qualified `provider_timeout` cause;
- successful facts carry the resulting observation ID; timeout facts cannot;
- resource ID alone is never treated as historical provider identity;
- no secret value, raw response, request body, ranking, learning, adaptive routing, candidate expansion or authority change;
- existing admission, readiness, selection, execution-time freshness and timeout-only fallback behavior remain unchanged.

Initial scope: six runtime/test files. Canonical CI must pass before mutation hardening and merge.