### PR TITLE
Qualify bounded exact-history ranking for configured cognition routes

### DIFF
--- a/src/grox/configured_cognition_route_execution.py
+++ b/src/grox/configured_cognition_route_execution.py
@@ -54,6 +54,9 @@ class ConfiguredCognitionRouteExecutionResult:
     attempt_readiness_age_seconds: Mapping[str, float]
     attempt_performance: tuple[ConfiguredCognitionAttemptPerformance, ...]
     executed: SelectedConfiguredCognitionResult
+    ranking_evaluated: bool = False
+    ranking_applied: bool = False
+    baseline_ready_resource_ids: tuple[str, ...] = ()
 
     @property
     def switched(self) -> bool:
@@ -67,6 +70,9 @@ class ConfiguredCognitionRouteExecutionResult:
         return {
             "schema": "grox-configured-cognition-route-execution-v1",
             "candidate_order": list(self.candidate_order),
+            "baseline_ready_resource_ids": list(
+                self.baseline_ready_resource_ids or self.candidate_order
+            ),
             "attempted_resource_ids": list(self.attempted_resource_ids),
             "timed_out_resource_ids": list(self.timed_out_resource_ids),
             "attempt_readiness_age_seconds": dict(self.attempt_readiness_age_seconds),
@@ -86,8 +92,9 @@ class ConfiguredCognitionRouteExecutionResult:
             "fallback_reason": "provider_timeout" if self.switched else None,
             "timeout_only_fallback": True,
             "candidate_expansion": False,
-            "adaptive_routing_enabled": False,
-            "ranking_enabled": False,
+            "adaptive_routing_enabled": self.ranking_applied,
+            "ranking_enabled": self.ranking_evaluated,
+            "ranking_applied": self.ranking_applied,
             "learning_enabled": False,
             "mission_created": False,
             "authority_changed": False,
@@ -278,6 +285,11 @@ class ConfiguredCognitionRouteExecution:
             attempt_readiness_age_seconds=MappingProxyType(dict(self._attempt_ages)),
             attempt_performance=(performance,),
             executed=executed,
+            ranking_evaluated=self._route.ranking_evaluated,
+            ranking_applied=self._route.ranking_applied,
+            baseline_ready_resource_ids=(
+                self._route.baseline_ready_resource_ids or self._route.ready_resource_ids
+            ),
         )
 
     def invoke(self, *, roster: list[dict[str, Any]]) -> ConfiguredCognitionRouteExecutionResult:
@@ -320,4 +332,9 @@ class ConfiguredCognitionRouteExecution:
             attempt_readiness_age_seconds=MappingProxyType(dict(self._attempt_ages)),
             attempt_performance=result.attempt_performance,
             executed=result.executed,
+            ranking_evaluated=self._route.ranking_evaluated,
+            ranking_applied=self._route.ranking_applied,
+            baseline_ready_resource_ids=(
+                self._route.baseline_ready_resource_ids or self._route.ready_resource_ids
+            ),
         )

--- a/src/grox/configured_cognition_route_plan.py
+++ b/src/grox/configured_cognition_route_plan.py
@@ -42,6 +42,16 @@ class ConfiguredCognitionRoutePlanResult:
         repr=False,
         compare=False,
     )
+    baseline_ready_resource_ids: tuple[str, ...] = ()
+    ranking_sample_counts: Mapping[str, int] = field(
+        default_factory=lambda: MappingProxyType({})
+    )
+    ranking_scores: Mapping[str, float] = field(
+        default_factory=lambda: MappingProxyType({})
+    )
+    ranking_evaluated: bool = False
+    ranking_applied: bool = False
+    ranking_reason: str = "not_requested"
 
     @property
     def ready_candidates(self) -> tuple[ConfiguredCognitionFallbackCandidate, ...]:
@@ -60,6 +70,9 @@ class ConfiguredCognitionRoutePlanResult:
             "candidate_order": list(self.candidate_order),
             "admitted_resource_ids": list(self.admitted_resource_ids),
             "ready_resource_ids": list(self.ready_resource_ids),
+            "baseline_ready_resource_ids": list(
+                self.baseline_ready_resource_ids or self.ready_resource_ids
+            ),
             "primary_resource_id": self.primary_resource_id,
             "fallback_resource_ids": list(self.fallback_resource_ids),
             "not_ready_reasons": dict(self.not_ready_reasons),
@@ -70,7 +83,16 @@ class ConfiguredCognitionRoutePlanResult:
             "fresh_readiness_revalidated_at_plan_time": True,
             "readiness_scope": "authenticated_model_visibility",
             "freshness_clock": "process_monotonic",
-            "deterministic_policy_order": True,
+            "deterministic_policy_order": not self.ranking_applied,
+            "deterministic_ranked_order": self.ranking_applied,
+            "ranking_evaluated": self.ranking_evaluated,
+            "ranking_applied": self.ranking_applied,
+            "ranking_reason": self.ranking_reason,
+            "ranking_sample_counts": dict(self.ranking_sample_counts),
+            "ranking_scores": dict(self.ranking_scores),
+            "ranking_score_basis": (
+                "laplace_timeout_reliability" if self.ranking_applied else None
+            ),
             "active_selection_created": False,
             "selected": False,
             "observed": False,
@@ -82,10 +104,10 @@ class ConfiguredCognitionRoutePlanResult:
             "fallback_invoked": False,
             "mission_created": False,
             "authority_changed": False,
-            "historical_scoring_used": False,
-            "ranking_enabled": False,
+            "historical_scoring_used": self.ranking_applied,
+            "ranking_enabled": self.ranking_evaluated,
             "learning_enabled": False,
-            "adaptive_scoring_enabled": False,
+            "adaptive_scoring_enabled": self.ranking_applied,
         }
 
 

--- a/src/grox/configured_cognition_route_ranking.py
+++ b/src/grox/configured_cognition_route_ranking.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import replace
+from types import MappingProxyType
+
+from .configured_cognition_attempt_performance import ConfiguredCognitionAttemptPerformance
+from .configured_cognition_route_plan import ConfiguredCognitionRoutePlanResult
+
+
+class ConfiguredCognitionRouteRankingError(RuntimeError):
+    """Configured cognition route history cannot be ranked safely."""
+
+
+class ConfiguredCognitionRouteRanker:
+    """Deterministically rank only the candidates already present in a current READY route.
+
+    History is advisory evidence, never authority. A candidate is matched only by
+    exact configured identity including credential alias and placement. The ranker
+    refuses current-Mission evidence and duplicate attempt identities. It changes
+    order only when every current READY candidate has the configured minimum exact
+    sample count; otherwise the existing policy order is preserved.
+    """
+
+    default_min_exact_samples = 2
+    max_exact_samples = 2_000
+
+    def __init__(
+        self,
+        route: ConfiguredCognitionRoutePlanResult,
+        history: Sequence[ConfiguredCognitionAttemptPerformance],
+        *,
+        min_exact_samples: int = default_min_exact_samples,
+    ):
+        if not isinstance(route, ConfiguredCognitionRoutePlanResult):
+            raise TypeError("route must be a ConfiguredCognitionRoutePlanResult")
+        if not isinstance(history, Sequence) or isinstance(history, (str, bytes)):
+            raise TypeError("history must be a sequence")
+        if len(history) > self.max_exact_samples:
+            raise ConfiguredCognitionRouteRankingError("configured cognition ranking history is unbounded")
+        if not all(isinstance(item, ConfiguredCognitionAttemptPerformance) for item in history):
+            raise TypeError("every history item must be ConfiguredCognitionAttemptPerformance")
+        if not isinstance(min_exact_samples, int) or isinstance(min_exact_samples, bool):
+            raise TypeError("min_exact_samples must be an integer")
+        if min_exact_samples < 1 or min_exact_samples > 100:
+            raise ValueError("min_exact_samples must be between 1 and 100")
+        if route.ranking_evaluated:
+            raise ConfiguredCognitionRouteRankingError("configured cognition route has already been ranked")
+
+        self._route = route
+        self._history = tuple(history)
+        self._min_exact_samples = min_exact_samples
+        self._validate_route_shape()
+        self._validate_history_identity()
+
+    def _validate_route_shape(self) -> None:
+        candidates = self._route.ready_candidates
+        ids = tuple(candidate.resource_id for candidate in candidates)
+        if not candidates or ids != self._route.ready_resource_ids:
+            raise ConfiguredCognitionRouteRankingError(
+                "current route READY candidate identity does not match route order"
+            )
+        if len(set(ids)) != len(ids):
+            raise ConfiguredCognitionRouteRankingError("current route contains duplicate READY resources")
+        if self._route.primary_resource_id != ids[0]:
+            raise ConfiguredCognitionRouteRankingError("current route primary identity drifted")
+        if self._route.fallback_resource_ids != ids[1:]:
+            raise ConfiguredCognitionRouteRankingError("current route fallback identity drifted")
+
+    def _validate_history_identity(self) -> None:
+        seen: set[tuple[str, str, str]] = set()
+        for item in self._history:
+            if item.mission_id == self._route.mission_id:
+                raise ConfiguredCognitionRouteRankingError(
+                    "current-Mission attempt evidence cannot influence current route ranking"
+                )
+            key = (item.mission_id, item.order_id, item.selection_id)
+            if key in seen:
+                raise ConfiguredCognitionRouteRankingError(
+                    "duplicate configured cognition attempt identity cannot influence ranking"
+                )
+            seen.add(key)
+
+    @staticmethod
+    def _matches_current_candidate(item, candidate) -> bool:
+        qualification = candidate.qualification
+        return (
+            item.resource_id == qualification.resource_id
+            and item.provider_kind == qualification.provider_kind
+            and item.model == qualification.model
+            and item.endpoint == qualification.endpoint
+            and item.credential_alias == qualification.credential_alias
+            and item.placement == candidate.fitness.placement
+        )
+
+    @staticmethod
+    def _laplace_reliability(items: tuple[ConfiguredCognitionAttemptPerformance, ...]) -> float:
+        successes = sum(item.succeeded for item in items)
+        return (successes + 1.0) / (len(items) + 2.0)
+
+    def rank(self) -> ConfiguredCognitionRoutePlanResult:
+        baseline = self._route.ready_resource_ids
+        samples: dict[str, tuple[ConfiguredCognitionAttemptPerformance, ...]] = {}
+        sample_counts: dict[str, int] = {}
+
+        for candidate in self._route.ready_candidates:
+            exact = tuple(
+                item for item in self._history
+                if self._matches_current_candidate(item, candidate)
+            )
+            samples[candidate.resource_id] = exact
+            sample_counts[candidate.resource_id] = len(exact)
+
+        if any(count < self._min_exact_samples for count in sample_counts.values()):
+            return replace(
+                self._route,
+                baseline_ready_resource_ids=baseline,
+                ranking_sample_counts=MappingProxyType(dict(sample_counts)),
+                ranking_scores=MappingProxyType({}),
+                ranking_evaluated=True,
+                ranking_applied=False,
+                ranking_reason="insufficient_exact_history",
+            )
+
+        scores = {
+            resource_id: self._laplace_reliability(items)
+            for resource_id, items in samples.items()
+        }
+        baseline_position = {resource_id: index for index, resource_id in enumerate(baseline)}
+        ranked_candidates = tuple(
+            sorted(
+                self._route.ready_candidates,
+                key=lambda candidate: (
+                    -scores[candidate.resource_id],
+                    baseline_position[candidate.resource_id],
+                ),
+            )
+        )
+        ranked_ids = tuple(candidate.resource_id for candidate in ranked_candidates)
+        return replace(
+            self._route,
+            ready_resource_ids=ranked_ids,
+            primary_resource_id=ranked_ids[0],
+            fallback_resource_ids=ranked_ids[1:],
+            _ready_candidates=ranked_candidates,
+            baseline_ready_resource_ids=baseline,
+            ranking_sample_counts=MappingProxyType(dict(sample_counts)),
+            ranking_scores=MappingProxyType(dict(scores)),
+            ranking_evaluated=True,
+            ranking_applied=True,
+            ranking_reason="exact_timeout_reliability",
+        )

--- a/tests/integration/test_configured_cognition_route_ranking.py
+++ b/tests/integration/test_configured_cognition_route_ranking.py
@@ -1,0 +1,293 @@
+from __future__ import annotations
+
+from pathlib import Path
+import tempfile
+from types import MappingProxyType
+import unittest
+from unittest.mock import patch
+
+from grox.cognition_discovery import ConfiguredCognitionDiscovery
+from grox.configured_cognition_attempt import ConfiguredCognitionAttempt
+from grox.configured_cognition_attempt_performance import ConfiguredCognitionAttemptPerformance
+from grox.configured_cognition_fallback import (
+    ConfiguredCognitionFallbackCandidate,
+    ConfiguredCognitionFallbackPolicy,
+)
+from grox.configured_cognition_fitness import ConfiguredCognitionFitnessResult
+from grox.configured_cognition_route_admission import ConfiguredCognitionRouteAdmission
+from grox.configured_cognition_route_execution import (
+    ConfiguredCognitionRouteExecution,
+    ConfiguredCognitionRouteExecutionError,
+)
+from grox.configured_cognition_route_plan import ConfiguredCognitionRoutePlan
+from grox.configured_cognition_route_ranking import ConfiguredCognitionRouteRanker
+from grox.configured_openai_cognition import ConfiguredOpenAICognition, ConfiguredOpenAICognitionResult
+from grox.contracts import MissionMode, MissionOrder
+from grox.reasoning.contracts import MissionInterpretation
+from grox.runtime_layout import VesselLayout
+from grox.selected_configured_cognition import SelectedConfiguredCognitionResult
+from grox.tools.layout_gateway import LayoutToolGateway
+from grox.tools.policy import GatewayPolicy
+from grox.tools.secrets import SecretBroker
+
+
+ENDPOINT = "https://api.openai.com/v1/responses"
+ORIGIN = "https://api.openai.com"
+INTENT = "Use exact history only inside current configured cognition gates"
+MISSION_ID = "MSN-configured-cognition-route-ranking-integration"
+ROSTER = [{"crew_id": "backend-engineer", "title": "Backend Engineer"}]
+
+
+def interpretation() -> MissionInterpretation:
+    return MissionInterpretation.from_mapping(
+        {
+            "commander_intent": INTENT,
+            "objective": "Execute a bounded evidence-ranked configured cognition route",
+            "ambiguous": False,
+            "ambiguities": [],
+            "assumptions": [],
+            "information_needs": [],
+            "candidate_crew_ids": ["backend-engineer"],
+            "options": [{
+                "name": "inspect",
+                "rationale": "bounded",
+                "advantages": ["bounded"],
+                "risks": [],
+                "crew_ids": ["backend-engineer"],
+            }],
+            "recommended_option": "inspect",
+            "confidence": 0.9,
+            "proposed_mode": "inspect",
+            "proposed_risk": "low",
+        },
+        expected_intent=INTENT,
+    )
+
+
+class ConfiguredCognitionRouteRankingIntegrationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def _candidate(self, model: str, alias: str) -> ConfiguredCognitionFallbackCandidate:
+        cfg = {
+            "GROX_REASONER_PROVIDER": "openai",
+            "GROX_REASONER_MODEL": model,
+            "GROX_REASONER_ENDPOINT": ENDPOINT,
+            "GROX_REASONER_CREDENTIAL_ALIAS": alias,
+        }
+        resource = ConfiguredCognitionDiscovery(cfg).inventory()["resources"][0]
+        order = MissionOrder.new(
+            MISSION_ID,
+            INTENT,
+            f"candidate {model}",
+            MissionMode.inspect,
+            "backend-engineer",
+            allowed_actions=("cognition_invoke", "net_fetch", "secret_use"),
+            parameters={
+                "operation": ConfiguredOpenAICognition.operation,
+                "resource_id": resource["resource_id"],
+                "provider_kind": "openai",
+                "model": model,
+                "endpoint": ENDPOINT,
+                "credential_alias": alias,
+                "allowed_origins": [ORIGIN],
+                "secret_grants": [alias],
+            },
+        ).seal()
+        qualification = ConfiguredOpenAICognitionResult(
+            resource_id=resource["resource_id"],
+            provider_kind="openai",
+            model=model,
+            endpoint=ENDPOINT,
+            credential_alias=alias,
+            mission_id=order.mission_id,
+            order_id=order.order_id,
+            response_id=f"resp-{model}",
+            response_model=model,
+            _interpretation=interpretation(),
+        )
+        fitness = ConfiguredCognitionFitnessResult(
+            status="PASS",
+            resource_id=qualification.resource_id,
+            provider_kind="openai",
+            model=model,
+            endpoint=ENDPOINT,
+            credential_alias=alias,
+            mission_id=order.mission_id,
+            order_id=order.order_id,
+            placement="mission_interpretation",
+            checks=MappingProxyType({"qualified": True}),
+        )
+        gateway = LayoutToolGateway(
+            VesselLayout.legacy(Path(self.tempdir.name)),
+            policy=GatewayPolicy(network_enabled=True, allowed_origins=frozenset({ORIGIN})),
+            secret_broker=SecretBroker({alias: f"SECRET-{alias}"}),
+        )
+        return ConfiguredCognitionFallbackCandidate(
+            config=cfg,
+            gateway=gateway,
+            qualification=qualification,
+            fitness=fitness,
+            order=order,
+        )
+
+    @staticmethod
+    def _probe(candidate: ConfiguredCognitionFallbackCandidate, observed: float) -> dict[str, object]:
+        q = candidate.qualification
+        return {
+            "schema": "grox-openai-authenticated-model-probe-v1",
+            "origin": ORIGIN,
+            "status": 200,
+            "classification": "authenticated_model_visible",
+            "requested_model": q.model,
+            "model_identity": q.model,
+            "metadata_valid": True,
+            "credential_alias": q.credential_alias,
+            "credential_accepted_for_model_visibility": True,
+            "credential_rejected": False,
+            "secret_materialized": True,
+            "network_invoked": True,
+            "response_body_returned": False,
+            "cognition_invoked": False,
+            "ready": False,
+            "qualified_fit": False,
+            "selected": False,
+            "authority_changed": False,
+            "resource_id": q.resource_id,
+            "provider_kind": "openai",
+            "endpoint": ENDPOINT,
+            "credential_use_authorized": True,
+            "observed_monotonic_seconds": observed,
+            "observation_clock": "process_monotonic",
+            "persistable_readiness_evidence": False,
+            "mission_created": False,
+            "observed": False,
+            "auto_selection": False,
+        }
+
+    @staticmethod
+    def _performance(candidate, number: int, outcome: str) -> ConfiguredCognitionAttemptPerformance:
+        return ConfiguredCognitionAttemptPerformance(
+            resource_id=candidate.resource_id,
+            provider_kind=candidate.qualification.provider_kind,
+            model=candidate.qualification.model,
+            endpoint=candidate.qualification.endpoint,
+            credential_alias=candidate.qualification.credential_alias,
+            mission_id=f"MSN-prior-{candidate.qualification.model}-{number}",
+            order_id=f"ORD-prior-{candidate.qualification.model}-{number}",
+            selection_id=f"SEL-prior-{candidate.qualification.model}-{number}",
+            placement=candidate.fitness.placement,
+            outcome=outcome,
+            observation_id=(
+                f"OBS-prior-{candidate.qualification.model}-{number}"
+                if outcome == "success"
+                else None
+            ),
+        )
+
+    @staticmethod
+    def _success(candidate) -> SelectedConfiguredCognitionResult:
+        return SelectedConfiguredCognitionResult(
+            observation_id=f"OBS-live-{candidate.qualification.model}",
+            selection_id=f"SEL-live-{candidate.qualification.model}",
+            resource_id=candidate.resource_id,
+            provider_kind=candidate.qualification.provider_kind,
+            model=candidate.qualification.model,
+            endpoint=candidate.qualification.endpoint,
+            mission_id=candidate.order.mission_id,
+            order_id=candidate.order.order_id,
+            placement=candidate.fitness.placement,
+            response_id=f"resp-live-{candidate.qualification.model}",
+            response_model=candidate.qualification.model,
+            _interpretation=interpretation(),
+        )
+
+    def _planned_and_ranked(self):
+        first = self._candidate("model-a", "alias-a")
+        second = self._candidate("model-b", "alias-b")
+        candidates = (first, second)
+        admission = ConfiguredCognitionRouteAdmission(
+            candidates,
+            ConfiguredCognitionFallbackPolicy(tuple(candidate.resource_id for candidate in candidates)),
+        ).plan()
+        probes = {
+            first.resource_id: self._probe(first, 150.0),
+            second.resource_id: self._probe(second, 100.0),
+        }
+        route = ConfiguredCognitionRoutePlan(
+            admission,
+            probes,
+            clock=lambda: 155.0,
+            max_age_seconds=60.0,
+        ).plan()
+        history = [
+            self._performance(first, 1, "provider_timeout"),
+            self._performance(first, 2, "provider_timeout"),
+            self._performance(second, 1, "success"),
+            self._performance(second, 2, "success"),
+        ]
+        ranked = ConfiguredCognitionRouteRanker(route, history).rank()
+        return first, second, probes, ranked
+
+    def test_ranked_ready_order_executes_through_existing_attempt_seam(self):
+        first, second, probes, ranked = self._planned_and_ranked()
+        calls: list[str] = []
+
+        def invoke_selected(attempt, selection, *, roster):
+            calls.append(attempt.resource_id)
+            return self._success(second)
+
+        with patch.object(ConfiguredCognitionAttempt, "invoke_selected", new=invoke_selected):
+            result = ConfiguredCognitionRouteExecution(
+                ranked,
+                probes,
+                clock=lambda: 159.0,
+                max_age_seconds=60.0,
+            ).invoke(roster=ROSTER)
+
+        self.assertEqual(ranked.baseline_ready_resource_ids, (first.resource_id, second.resource_id))
+        self.assertEqual(ranked.ready_resource_ids, (second.resource_id, first.resource_id))
+        self.assertEqual(calls, [second.resource_id])
+        self.assertEqual(result.executed.resource_id, second.resource_id)
+        self.assertTrue(result.ranking_evaluated)
+        self.assertTrue(result.ranking_applied)
+        self.assertEqual(
+            result.baseline_ready_resource_ids,
+            (first.resource_id, second.resource_id),
+        )
+        evidence = result.evidence()
+        self.assertTrue(evidence["ranking_enabled"])
+        self.assertTrue(evidence["ranking_applied"])
+        self.assertTrue(evidence["adaptive_routing_enabled"])
+        self.assertFalse(evidence["learning_enabled"])
+        self.assertFalse(evidence["candidate_expansion"])
+        self.assertFalse(evidence["authority_changed"])
+
+    def test_ranked_primary_expiry_still_hard_stops_before_selection(self):
+        first, second, probes, ranked = self._planned_and_ranked()
+        self.assertEqual(ranked.primary_resource_id, second.resource_id)
+
+        with patch.object(
+            ConfiguredCognitionAttempt,
+            "select",
+            side_effect=AssertionError("stale ranked primary must fail before selection"),
+        ):
+            with self.assertRaises(ConfiguredCognitionRouteExecutionError) as caught:
+                ConfiguredCognitionRouteExecution(
+                    ranked,
+                    probes,
+                    clock=lambda: 161.0,
+                    max_age_seconds=60.0,
+                ).invoke(roster=ROSTER)
+
+        self.assertEqual(caught.exception.resource_id, second.resource_id)
+        self.assertEqual(caught.exception.reason, "stale_authenticated_model_visibility")
+        self.assertEqual(caught.exception.observation_age_seconds, 61.0)
+        self.assertEqual(ranked.fallback_resource_ids, (first.resource_id,))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/mutation/run_critical_invariants.py
+++ b/tests/mutation/run_critical_invariants.py
@@ -336,6 +336,14 @@ SPECS: tuple[MutationSpec, ...] = (
         nodeid="tests/unit/test_configured_cognition_route_execution.py::ConfiguredCognitionRouteExecutionTests::test_timeout_advances_only_to_fallback_that_is_fresh_at_its_own_attempt",
     ),
     MutationSpec(
+        name="configured-cognition-route-ranking-exact-credential-alias-history",
+        invariant="Configured cognition route ranking must never attribute prior attempt history across a credential-alias rebind.",
+        path="src/grox/configured_cognition_route_ranking.py",
+        old='            and item.credential_alias == qualification.credential_alias\n',
+        new='            and True  # deliberate mutation: ignore credential alias history identity\n',
+        nodeid="tests/unit/test_configured_cognition_route_ranking.py::ConfiguredCognitionRouteRankingTests::test_credential_alias_rebind_history_is_not_attributed_to_current_identity",
+    ),
+    MutationSpec(
         name="ci-action-immutable-pin",
         invariant="Third-party GitHub Actions must remain pinned to immutable full commit SHAs.",
         path=".github/workflows/ci.yml",

--- a/tests/unit/test_configured_cognition_route_ranking.py
+++ b/tests/unit/test_configured_cognition_route_ranking.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+from pathlib import Path
+import tempfile
+from types import MappingProxyType
+import unittest
+
+from grox.cognition_discovery import ConfiguredCognitionDiscovery
+from grox.configured_cognition_attempt_performance import ConfiguredCognitionAttemptPerformance
+from grox.configured_cognition_fallback import ConfiguredCognitionFallbackCandidate
+from grox.configured_cognition_fitness import ConfiguredCognitionFitnessResult
+from grox.configured_cognition_route_plan import ConfiguredCognitionRoutePlanResult
+from grox.configured_cognition_route_ranking import (
+    ConfiguredCognitionRouteRanker,
+    ConfiguredCognitionRouteRankingError,
+)
+from grox.configured_openai_cognition import ConfiguredOpenAICognition, ConfiguredOpenAICognitionResult
+from grox.contracts import MissionMode, MissionOrder
+from grox.reasoning.contracts import MissionInterpretation
+from grox.runtime_layout import VesselLayout
+from grox.tools.layout_gateway import LayoutToolGateway
+from grox.tools.policy import GatewayPolicy
+from grox.tools.secrets import SecretBroker
+
+
+ENDPOINT = "https://api.openai.com/v1/responses"
+ORIGIN = "https://api.openai.com"
+INTENT = "Rank only current ready configured cognition candidates"
+MISSION_ID = "MSN-configured-cognition-route-ranking"
+
+
+def interpretation() -> MissionInterpretation:
+    return MissionInterpretation.from_mapping(
+        {
+            "commander_intent": INTENT,
+            "objective": "Rank a bounded current configured cognition route",
+            "ambiguous": False,
+            "ambiguities": [],
+            "assumptions": [],
+            "information_needs": [],
+            "candidate_crew_ids": ["backend-engineer"],
+            "options": [{
+                "name": "inspect",
+                "rationale": "bounded",
+                "advantages": ["bounded"],
+                "risks": [],
+                "crew_ids": ["backend-engineer"],
+            }],
+            "recommended_option": "inspect",
+            "confidence": 0.9,
+            "proposed_mode": "inspect",
+            "proposed_risk": "low",
+        },
+        expected_intent=INTENT,
+    )
+
+
+class ConfiguredCognitionRouteRankingTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def _candidate(self, model: str, alias: str) -> ConfiguredCognitionFallbackCandidate:
+        cfg = {
+            "GROX_REASONER_PROVIDER": "openai",
+            "GROX_REASONER_MODEL": model,
+            "GROX_REASONER_ENDPOINT": ENDPOINT,
+            "GROX_REASONER_CREDENTIAL_ALIAS": alias,
+        }
+        resource = ConfiguredCognitionDiscovery(cfg).inventory()["resources"][0]
+        order = MissionOrder.new(
+            MISSION_ID,
+            INTENT,
+            f"rank candidate {model}",
+            MissionMode.inspect,
+            "backend-engineer",
+            allowed_actions=("cognition_invoke", "net_fetch", "secret_use"),
+            parameters={
+                "operation": ConfiguredOpenAICognition.operation,
+                "resource_id": resource["resource_id"],
+                "provider_kind": "openai",
+                "model": model,
+                "endpoint": ENDPOINT,
+                "credential_alias": alias,
+                "allowed_origins": [ORIGIN],
+                "secret_grants": [alias],
+            },
+        ).seal()
+        qualification = ConfiguredOpenAICognitionResult(
+            resource_id=resource["resource_id"],
+            provider_kind="openai",
+            model=model,
+            endpoint=ENDPOINT,
+            credential_alias=alias,
+            mission_id=order.mission_id,
+            order_id=order.order_id,
+            response_id=f"resp-{model}",
+            response_model=model,
+            _interpretation=interpretation(),
+        )
+        fitness = ConfiguredCognitionFitnessResult(
+            status="PASS",
+            resource_id=qualification.resource_id,
+            provider_kind="openai",
+            model=model,
+            endpoint=ENDPOINT,
+            credential_alias=alias,
+            mission_id=order.mission_id,
+            order_id=order.order_id,
+            placement="mission_interpretation",
+            checks=MappingProxyType({"qualified": True}),
+        )
+        gateway = LayoutToolGateway(
+            VesselLayout.legacy(Path(self.tempdir.name)),
+            policy=GatewayPolicy(network_enabled=True, allowed_origins=frozenset({ORIGIN})),
+            secret_broker=SecretBroker({alias: f"SECRET-{alias}"}),
+        )
+        return ConfiguredCognitionFallbackCandidate(
+            config=cfg,
+            gateway=gateway,
+            qualification=qualification,
+            fitness=fitness,
+            order=order,
+        )
+
+    @staticmethod
+    def _route(*candidates: ConfiguredCognitionFallbackCandidate) -> ConfiguredCognitionRoutePlanResult:
+        ids = tuple(candidate.resource_id for candidate in candidates)
+        return ConfiguredCognitionRoutePlanResult(
+            candidate_order=ids,
+            admitted_resource_ids=ids,
+            ready_resource_ids=ids,
+            primary_resource_id=ids[0],
+            fallback_resource_ids=ids[1:],
+            not_ready_reasons=MappingProxyType({}),
+            mission_id=MISSION_ID,
+            placement="mission_interpretation",
+            _ready_candidates=tuple(candidates),
+        )
+
+    @staticmethod
+    def _performance(
+        candidate: ConfiguredCognitionFallbackCandidate,
+        *,
+        number: int,
+        outcome: str,
+        alias: str | None = None,
+        mission_prefix: str = "MSN-history",
+    ) -> ConfiguredCognitionAttemptPerformance:
+        return ConfiguredCognitionAttemptPerformance(
+            resource_id=candidate.resource_id,
+            provider_kind=candidate.qualification.provider_kind,
+            model=candidate.qualification.model,
+            endpoint=candidate.qualification.endpoint,
+            credential_alias=alias or candidate.qualification.credential_alias,
+            mission_id=f"{mission_prefix}-{number}",
+            order_id=f"ORD-history-{candidate.qualification.model}-{number}",
+            selection_id=f"SEL-history-{candidate.qualification.model}-{number}",
+            placement=candidate.fitness.placement,
+            outcome=outcome,
+            observation_id=(
+                f"OBS-history-{candidate.qualification.model}-{number}"
+                if outcome == "success"
+                else None
+            ),
+        )
+
+    def test_exact_timeout_reliability_reorders_only_current_ready_candidates(self):
+        first = self._candidate("model-a", "alias-a")
+        second = self._candidate("model-b", "alias-b")
+        unrelated = self._candidate("model-c", "alias-c")
+        route = self._route(first, second)
+        history = [
+            self._performance(first, number=1, outcome="provider_timeout"),
+            self._performance(first, number=2, outcome="provider_timeout"),
+            self._performance(second, number=1, outcome="success"),
+            self._performance(second, number=2, outcome="success"),
+            self._performance(unrelated, number=1, outcome="success"),
+            self._performance(unrelated, number=2, outcome="success"),
+        ]
+
+        ranked = ConfiguredCognitionRouteRanker(route, history).rank()
+
+        self.assertEqual(ranked.baseline_ready_resource_ids, (first.resource_id, second.resource_id))
+        self.assertEqual(ranked.ready_resource_ids, (second.resource_id, first.resource_id))
+        self.assertEqual(ranked.primary_resource_id, second.resource_id)
+        self.assertEqual(ranked.fallback_resource_ids, (first.resource_id,))
+        self.assertEqual(set(ranked.ready_resource_ids), {first.resource_id, second.resource_id})
+        self.assertNotIn(unrelated.resource_id, ranked.ready_resource_ids)
+        self.assertTrue(ranked.ranking_evaluated)
+        self.assertTrue(ranked.ranking_applied)
+        self.assertEqual(ranked.ranking_reason, "exact_timeout_reliability")
+        self.assertEqual(ranked.ranking_sample_counts[first.resource_id], 2)
+        self.assertEqual(ranked.ranking_sample_counts[second.resource_id], 2)
+        self.assertEqual(ranked.ranking_scores[first.resource_id], 0.25)
+        self.assertEqual(ranked.ranking_scores[second.resource_id], 0.75)
+        self.assertEqual(ranked.fallback_policy.candidate_order, ranked.ready_resource_ids)
+        evidence = ranked.evidence()
+        self.assertTrue(evidence["ranking_enabled"])
+        self.assertTrue(evidence["adaptive_scoring_enabled"])
+        self.assertFalse(evidence["learning_enabled"])
+        self.assertFalse(evidence["candidate_expansion"])
+        self.assertFalse(evidence["authority_changed"])
+
+    def test_credential_alias_rebind_history_is_not_attributed_to_current_identity(self):
+        first = self._candidate("model-a", "alias-current-a")
+        second = self._candidate("model-b", "alias-current-b")
+        route = self._route(first, second)
+        history = [
+            self._performance(first, number=1, outcome="provider_timeout"),
+            self._performance(first, number=2, outcome="provider_timeout"),
+            self._performance(second, number=1, outcome="success", alias="alias-old-b"),
+            self._performance(second, number=2, outcome="success", alias="alias-old-b"),
+        ]
+
+        ranked = ConfiguredCognitionRouteRanker(route, history).rank()
+
+        self.assertFalse(ranked.ranking_applied)
+        self.assertTrue(ranked.ranking_evaluated)
+        self.assertEqual(ranked.ranking_reason, "insufficient_exact_history")
+        self.assertEqual(ranked.ready_resource_ids, route.ready_resource_ids)
+        self.assertEqual(ranked.ranking_sample_counts[first.resource_id], 2)
+        self.assertEqual(ranked.ranking_sample_counts[second.resource_id], 0)
+        self.assertEqual(dict(ranked.ranking_scores), {})
+
+    def test_tied_exact_history_preserves_existing_current_ready_order(self):
+        first = self._candidate("model-a", "alias-a")
+        second = self._candidate("model-b", "alias-b")
+        route = self._route(first, second)
+        history = [
+            self._performance(first, number=1, outcome="success"),
+            self._performance(first, number=2, outcome="provider_timeout"),
+            self._performance(second, number=1, outcome="provider_timeout"),
+            self._performance(second, number=2, outcome="success"),
+        ]
+
+        ranked = ConfiguredCognitionRouteRanker(route, history).rank()
+
+        self.assertTrue(ranked.ranking_applied)
+        self.assertEqual(ranked.ranking_scores[first.resource_id], 0.5)
+        self.assertEqual(ranked.ranking_scores[second.resource_id], 0.5)
+        self.assertEqual(ranked.ready_resource_ids, route.ready_resource_ids)
+
+    def test_current_mission_and_duplicate_attempt_identity_fail_closed(self):
+        first = self._candidate("model-a", "alias-a")
+        second = self._candidate("model-b", "alias-b")
+        route = self._route(first, second)
+        current = self._performance(
+            first,
+            number=1,
+            outcome="success",
+            mission_prefix=MISSION_ID.rsplit("-", 1)[0],
+        )
+        # Make the constructed Mission ID exactly equal the current route Mission.
+        current = ConfiguredCognitionAttemptPerformance(
+            resource_id=current.resource_id,
+            provider_kind=current.provider_kind,
+            model=current.model,
+            endpoint=current.endpoint,
+            credential_alias=current.credential_alias,
+            mission_id=MISSION_ID,
+            order_id=current.order_id,
+            selection_id=current.selection_id,
+            placement=current.placement,
+            outcome=current.outcome,
+            observation_id=current.observation_id,
+        )
+        with self.assertRaisesRegex(ConfiguredCognitionRouteRankingError, "current-Mission"):
+            ConfiguredCognitionRouteRanker(route, [current])
+
+        duplicate = self._performance(first, number=7, outcome="success")
+        with self.assertRaisesRegex(ConfiguredCognitionRouteRankingError, "duplicate"):
+            ConfiguredCognitionRouteRanker(route, [duplicate, duplicate])
+
+    def test_insufficient_exact_history_preserves_policy_order_for_every_candidate(self):
+        first = self._candidate("model-a", "alias-a")
+        second = self._candidate("model-b", "alias-b")
+        route = self._route(first, second)
+        history = [
+            self._performance(first, number=1, outcome="provider_timeout"),
+            self._performance(first, number=2, outcome="provider_timeout"),
+            self._performance(second, number=1, outcome="success"),
+        ]
+
+        ranked = ConfiguredCognitionRouteRanker(route, history).rank()
+
+        self.assertEqual(ranked.ready_resource_ids, route.ready_resource_ids)
+        self.assertFalse(ranked.ranking_applied)
+        self.assertEqual(ranked.ranking_reason, "insufficient_exact_history")
+        self.assertFalse(ranked.evidence()["adaptive_scoring_enabled"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #197
Parent: #115

Development-first runtime slice from canonical `main@af9b01d55881915262b1f252dde12ae453e91e30`.

Boundary:
- ranks only candidates already present in a current admitted + freshly READY route;
- matches historical attempt evidence by exact resource/provider/model/endpoint/credential-alias/placement identity;
- resource ID alone is insufficient;
- current-Mission evidence and duplicate attempt identities fail closed;
- ranking applies only when every current READY candidate has at least two exact historical attempts; otherwise current policy order is preserved;
- score is deterministic Laplace timeout reliability: `(successes + 1) / (samples + 2)`;
- ties preserve current READY policy order;
- unrelated history cannot expand the route;
- no persistence, learning, latency/cost inference, discovery, authorization, readiness promotion, fitness promotion, Mission creation, or authority widening;
- execution-time freshness remains the final pre-attempt gate.

Initial scope: five runtime/test files. Canonical CI must pass before mutation hardening and merge.