### PR TITLE
Qualify bounded multi-resource configured cognition catalog

### DIFF
--- a/src/grox/cognition_discovery.py
+++ b/src/grox/cognition_discovery.py
@@ -2,18 +2,23 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 import hashlib
+import json
 import os
 import re
 from typing import Any
 from urllib.parse import urlsplit, urlunsplit
 
 
-_NONSECRET_ENV_KEYS = (
+_LEGACY_NONSECRET_ENV_KEYS = (
     "GROX_REASONER_PROVIDER",
     "GROX_REASONER_MODEL",
     "GROX_REASONER_ENDPOINT",
     "GROX_REASONER_CREDENTIAL_ALIAS",
 )
+_CATALOG_ENV_KEY = "GROX_REASONER_CATALOG_JSON"
+_NONSECRET_ENV_KEYS = (*_LEGACY_NONSECRET_ENV_KEYS, _CATALOG_ENV_KEY)
+_CATALOG_ALLOWED_FIELDS = frozenset({"provider_kind", "model", "endpoint", "credential_alias"})
+_MAX_CATALOG_ENTRIES = 8
 _SUPPORTED_PROVIDER_KINDS = frozenset({"openai", "local-llama-cpp"})
 _DEFAULT_OPENAI_ENDPOINT = "https://api.openai.com/v1/responses"
 
@@ -63,6 +68,16 @@ def _safe_endpoint(value: Any) -> str | None:
     path = parsed.path or "/"
     normalized = urlunsplit((parsed.scheme.lower(), netloc, path, "", ""))
     return normalized if normalized == value.strip() else None
+
+
+def _safe_credential_alias(value: Any) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        return None
+    if not re.fullmatch(r"[A-Za-z0-9_.:@-]{1,128}", value):
+        return None
+    return value
 
 
 def _resource_id(*, provider_kind: str, model: str, endpoint: str | None) -> str:
@@ -122,7 +137,145 @@ class ConfiguredCognitionDiscovery:
             "auto_selection": False,
         }
 
+    @staticmethod
+    def _catalog_entry_config(entry: Any) -> dict[str, str] | None:
+        if not isinstance(entry, Mapping):
+            return None
+        if set(entry) - _CATALOG_ALLOWED_FIELDS:
+            return None
+
+        provider_raw = entry.get("provider_kind")
+        if not isinstance(provider_raw, str):
+            return None
+        provider_kind = provider_raw.strip().lower()
+        if provider_kind not in _SUPPORTED_PROVIDER_KINDS:
+            return None
+
+        model = _safe_identity(entry.get("model"))
+        if model is None:
+            return None
+
+        config = {
+            "GROX_REASONER_PROVIDER": provider_kind,
+            "GROX_REASONER_MODEL": model,
+        }
+        alias_raw = entry.get("credential_alias")
+        alias = _safe_credential_alias(alias_raw)
+        if alias_raw is not None and alias is None:
+            return None
+
+        if provider_kind == "openai":
+            endpoint = _safe_endpoint(entry.get("endpoint"))
+            if endpoint is None:
+                return None
+            config["GROX_REASONER_ENDPOINT"] = endpoint
+            if alias is not None:
+                config["GROX_REASONER_CREDENTIAL_ALIAS"] = alias
+        else:
+            if entry.get("endpoint") is not None or alias_raw is not None:
+                return None
+
+        return config
+
+    def _catalog_configs(self) -> tuple[str, tuple[dict[str, str], ...]]:
+        raw = self._config.get(_CATALOG_ENV_KEY)
+        if not isinstance(raw, str) or not raw:
+            return "unconfigured", ()
+
+        if any(self._config.get(key) for key in _LEGACY_NONSECRET_ENV_KEYS):
+            return "ambiguous", ()
+        if len(raw) > 32_768:
+            return "invalid_catalog", ()
+
+        try:
+            payload = json.loads(raw)
+        except (json.JSONDecodeError, TypeError, ValueError):
+            return "invalid_catalog", ()
+        if (
+            not isinstance(payload, list)
+            or isinstance(payload, (str, bytes))
+            or not 1 <= len(payload) <= _MAX_CATALOG_ENTRIES
+        ):
+            return "invalid_catalog", ()
+
+        normalized: list[dict[str, str]] = []
+        resource_ids: set[str] = set()
+        for entry in payload:
+            config = self._catalog_entry_config(entry)
+            if config is None:
+                return "invalid_catalog", ()
+            provider_kind = config["GROX_REASONER_PROVIDER"]
+            model = config["GROX_REASONER_MODEL"]
+            endpoint = config.get("GROX_REASONER_ENDPOINT")
+            resource_id = _resource_id(
+                provider_kind=provider_kind,
+                model=model,
+                endpoint=endpoint,
+            )
+            if resource_id in resource_ids:
+                return "invalid_catalog", ()
+            resource_ids.add(resource_id)
+            normalized.append(config)
+        return "ok", tuple(normalized)
+
+    def declared_configs(self) -> tuple[dict[str, str], ...]:
+        """Return normalized non-secret declarations for internal bounded composition.
+
+        Credential aliases may be present because alias names are non-secret
+        identity metadata. Secret values are never read or returned here.
+        """
+        if self._config.get(_CATALOG_ENV_KEY):
+            status, configs = self._catalog_configs()
+            return tuple(dict(item) for item in configs) if status == "ok" else ()
+
+        raw_provider = self._config.get("GROX_REASONER_PROVIDER", "")
+        provider_kind = raw_provider.strip().lower()
+        if not provider_kind or provider_kind in {"none", "off", "disabled"}:
+            return ()
+        if provider_kind not in _SUPPORTED_PROVIDER_KINDS:
+            return ()
+
+        model = _safe_identity(self._config.get("GROX_REASONER_MODEL"))
+        if model is None:
+            return ()
+
+        config = {
+            "GROX_REASONER_PROVIDER": provider_kind,
+            "GROX_REASONER_MODEL": model,
+        }
+        if provider_kind == "openai":
+            endpoint = _safe_endpoint(
+                self._config.get("GROX_REASONER_ENDPOINT", _DEFAULT_OPENAI_ENDPOINT)
+            )
+            if endpoint is None:
+                return ()
+            config["GROX_REASONER_ENDPOINT"] = endpoint
+            alias_raw = self._config.get("GROX_REASONER_CREDENTIAL_ALIAS")
+            if alias_raw:
+                alias = _safe_credential_alias(alias_raw)
+                if alias is None:
+                    return ()
+                config["GROX_REASONER_CREDENTIAL_ALIAS"] = alias
+        return (config,)
+
     def inventory(self) -> dict[str, Any]:
+        if self._config.get(_CATALOG_ENV_KEY):
+            status, configs = self._catalog_configs()
+            if status != "ok":
+                return self._base_inventory(status=status, resources=[])
+            resources = [
+                self._resource(
+                    provider_kind=config["GROX_REASONER_PROVIDER"],
+                    model=config["GROX_REASONER_MODEL"],
+                    endpoint=config.get("GROX_REASONER_ENDPOINT"),
+                )
+                for config in configs
+            ]
+            result = self._base_inventory(status="ok", resources=resources)
+            result["configuration_source"] = "explicit_catalog"
+            result["catalog_entry_count"] = len(resources)
+            return result
+
         raw_provider = self._config.get("GROX_REASONER_PROVIDER", "")
         provider_kind = raw_provider.strip().lower()
         if not provider_kind or provider_kind in {"none", "off", "disabled"}:
@@ -130,16 +283,16 @@ class ConfiguredCognitionDiscovery:
         if provider_kind not in _SUPPORTED_PROVIDER_KINDS:
             return self._base_inventory(status="unsupported", resources=[])
 
-        model = _safe_identity(self._config.get("GROX_REASONER_MODEL"))
-        if model is None:
+        configs = self.declared_configs()
+        if len(configs) != 1:
             return self._base_inventory(status="incomplete", resources=[])
-
-        endpoint: str | None = None
-        if provider_kind == "openai":
-            raw_endpoint = self._config.get("GROX_REASONER_ENDPOINT", _DEFAULT_OPENAI_ENDPOINT)
-            endpoint = _safe_endpoint(raw_endpoint)
-            if endpoint is None:
-                return self._base_inventory(status="incomplete", resources=[])
-
-        resource = self._resource(provider_kind=provider_kind, model=model, endpoint=endpoint)
-        return self._base_inventory(status="ok", resources=[resource])
+        config = configs[0]
+        resource = self._resource(
+            provider_kind=config["GROX_REASONER_PROVIDER"],
+            model=config["GROX_REASONER_MODEL"],
+            endpoint=config.get("GROX_REASONER_ENDPOINT"),
+        )
+        result = self._base_inventory(status="ok", resources=[resource])
+        result["configuration_source"] = "legacy_single"
+        result["catalog_entry_count"] = 1
+        return result

--- a/src/grox/cognition_discovery.py
+++ b/src/grox/cognition_discovery.py
@@ -251,10 +251,8 @@ class ConfiguredCognitionDiscovery:
                 return ()
             config["GROX_REASONER_ENDPOINT"] = endpoint
             alias_raw = self._config.get("GROX_REASONER_CREDENTIAL_ALIAS")
-            if alias_raw:
-                alias = _safe_credential_alias(alias_raw)
-                if alias is None:
-                    return ()
+            alias = _safe_credential_alias(alias_raw)
+            if alias is not None:
                 config["GROX_REASONER_CREDENTIAL_ALIAS"] = alias
         return (config,)
 

--- a/tests/integration/test_configured_cognition_discovery.py
+++ b/tests/integration/test_configured_cognition_discovery.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import json
 import tempfile
 import unittest
 from unittest.mock import patch
@@ -38,6 +39,48 @@ class PilotConfiguredCognitionDiscoveryTests(unittest.TestCase):
             self.assertFalse(item["observed"])
             self.assertNotIn("SUPER-SECRET-SENTINEL", repr(inventory))
             self.assertEqual(pilot.store.recent_missions(), [])
+
+    def test_pilot_catalog_inventory_is_multi_resource_read_only_and_privacy_minimized(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            reasoner = object()
+            pilot = PilotGorXu(root, reasoner=reasoner)
+            raw_catalog = json.dumps([
+                {
+                    "provider_kind": "openai",
+                    "model": "remote-model-a",
+                    "endpoint": "https://api.openai.com/v1/responses",
+                    "credential_alias": "openai-a",
+                },
+                {
+                    "provider_kind": "local-llama-cpp",
+                    "model": "local-model-b",
+                },
+            ])
+
+            with patch.dict(
+                "os.environ",
+                {"GROX_REASONER_CATALOG_JSON": raw_catalog},
+                clear=True,
+            ):
+                inventory = pilot.live_configured_cognition_inventory()
+
+            self.assertIs(pilot.reasoner, reasoner)
+            self.assertEqual(inventory["status"], "ok")
+            self.assertEqual(inventory["configuration_source"], "explicit_catalog")
+            self.assertEqual(inventory["catalog_entry_count"], 2)
+            self.assertEqual(
+                [item["model"] for item in inventory["resources"]],
+                ["remote-model-a", "local-model-b"],
+            )
+            self.assertNotIn("openai-a", repr(inventory))
+            self.assertNotIn("credential_alias", repr(inventory))
+            self.assertEqual(pilot.store.recent_missions(), [])
+            self.assertFalse(inventory["network_invoked"])
+            self.assertFalse(inventory["credential_inspected"])
+            self.assertFalse(inventory["authority_changed"])
+            self.assertFalse(inventory["auto_activation"])
+            self.assertFalse(inventory["auto_selection"])
 
 
 if __name__ == "__main__":

--- a/tests/mutation/run_critical_invariants.py
+++ b/tests/mutation/run_critical_invariants.py
@@ -344,6 +344,14 @@ SPECS: tuple[MutationSpec, ...] = (
         nodeid="tests/unit/test_configured_cognition_route_ranking.py::ConfiguredCognitionRouteRankingTests::test_credential_alias_rebind_history_is_not_attributed_to_current_identity",
     ),
     MutationSpec(
+        name="configured-cognition-catalog-rejects-duplicate-resource",
+        invariant="Configured cognition catalog discovery must reject duplicate configured resource identities instead of exposing an ambiguous routable candidate set.",
+        path="src/grox/cognition_discovery.py",
+        old='            if resource_id in resource_ids:\n                return "invalid_catalog", ()\n',
+        new='            if False and resource_id in resource_ids:\n                return "invalid_catalog", ()\n',
+        nodeid="tests/unit/test_configured_cognition_discovery.py::ConfiguredCognitionDiscoveryTests::test_catalog_malformed_unsupported_duplicate_and_over_limit_fail_closed_without_partial_inventory",
+    ),
+    MutationSpec(
         name="ci-action-immutable-pin",
         invariant="Third-party GitHub Actions must remain pinned to immutable full commit SHAs.",
         path=".github/workflows/ci.yml",

--- a/tests/unit/test_configured_cognition_discovery.py
+++ b/tests/unit/test_configured_cognition_discovery.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import unittest
 from unittest.mock import patch
 
@@ -99,6 +100,145 @@ class ConfiguredCognitionDiscoveryTests(unittest.TestCase):
         self.assertNotIn(secret, encoded)
         self.assertNotIn("PRIVATE-SENTINEL", encoded)
         self.assertNotIn("OPENAI_API_KEY", encoded)
+
+    def test_explicit_catalog_discovers_multiple_resources_in_declared_order_without_alias_exposure(self):
+        catalog = [
+            {
+                "provider_kind": "openai",
+                "model": "remote-model-a",
+                "endpoint": "https://api.openai.com/v1/responses",
+                "credential_alias": "openai-a",
+            },
+            {
+                "provider_kind": "local-llama-cpp",
+                "model": "local-model-b",
+            },
+            {
+                "provider_kind": "openai",
+                "model": "remote-model-c",
+                "endpoint": "https://api.openai.com/v1/responses",
+                "credential_alias": "openai-c",
+            },
+        ]
+        config = {"GROX_REASONER_CATALOG_JSON": json.dumps(catalog)}
+
+        discovery = ConfiguredCognitionDiscovery(config)
+        inventory = discovery.inventory()
+        declared = discovery.declared_configs()
+
+        self.assertEqual(inventory["status"], "ok")
+        self.assertEqual(inventory["configuration_source"], "explicit_catalog")
+        self.assertEqual(inventory["catalog_entry_count"], 3)
+        self.assertEqual(
+            [item["model"] for item in inventory["resources"]],
+            ["remote-model-a", "local-model-b", "remote-model-c"],
+        )
+        self.assertEqual(
+            [item["provider_kind"] for item in inventory["resources"]],
+            ["openai", "local-llama-cpp", "openai"],
+        )
+        self.assertEqual(declared[0]["GROX_REASONER_CREDENTIAL_ALIAS"], "openai-a")
+        self.assertEqual(declared[2]["GROX_REASONER_CREDENTIAL_ALIAS"], "openai-c")
+        self.assertNotIn("credential_alias", repr(inventory))
+        self.assertNotIn("openai-a", repr(inventory))
+        self.assertNotIn("openai-c", repr(inventory))
+        self.assertEqual(len({item["resource_id"] for item in inventory["resources"]}), 3)
+        for item in inventory["resources"]:
+            self.assertTrue(item["discovered"])
+            self.assertFalse(item["authorized"])
+            self.assertFalse(item["ready"])
+            self.assertFalse(item["qualified_fit"])
+            self.assertFalse(item["selected"])
+            self.assertFalse(item["observed"])
+
+    def test_catalog_and_legacy_single_configuration_are_mutually_exclusive(self):
+        config = {
+            "GROX_REASONER_CATALOG_JSON": json.dumps(
+                [{
+                    "provider_kind": "openai",
+                    "model": "catalog-model",
+                    "endpoint": "https://api.openai.com/v1/responses",
+                }]
+            ),
+            "GROX_REASONER_PROVIDER": "openai",
+            "GROX_REASONER_MODEL": "legacy-model",
+        }
+
+        discovery = ConfiguredCognitionDiscovery(config)
+        inventory = discovery.inventory()
+
+        self.assertEqual(inventory["status"], "ambiguous")
+        self.assertEqual(inventory["resources"], [])
+        self.assertEqual(discovery.declared_configs(), ())
+
+    def test_catalog_malformed_unsupported_duplicate_and_over_limit_fail_closed_without_partial_inventory(self):
+        valid = {
+            "provider_kind": "openai",
+            "model": "remote-model",
+            "endpoint": "https://api.openai.com/v1/responses",
+        }
+        cases = {
+            "malformed_json": "{not-json",
+            "wrong_shape": json.dumps({"provider_kind": "openai"}),
+            "unknown_field": json.dumps([{**valid, "priority": 1}]),
+            "unsupported": json.dumps([{
+                "provider_kind": "unknown-provider",
+                "model": "remote-model",
+                "endpoint": "https://example.invalid/v1/responses",
+            }]),
+            "incomplete_remote": json.dumps([{
+                "provider_kind": "openai",
+                "model": "remote-model",
+            }]),
+            "local_remote_metadata": json.dumps([{
+                "provider_kind": "local-llama-cpp",
+                "model": "local-model",
+                "endpoint": "http://127.0.0.1:8080/v1/responses",
+            }]),
+            "duplicate_resource": json.dumps([
+                {**valid, "credential_alias": "alias-a"},
+                {**valid, "credential_alias": "alias-b"},
+            ]),
+            "over_limit": json.dumps([
+                {
+                    "provider_kind": "openai",
+                    "model": f"model-{index}",
+                    "endpoint": "https://api.openai.com/v1/responses",
+                }
+                for index in range(9)
+            ]),
+        }
+        for name, raw in cases.items():
+            with self.subTest(name=name):
+                discovery = ConfiguredCognitionDiscovery({"GROX_REASONER_CATALOG_JSON": raw})
+                inventory = discovery.inventory()
+                self.assertEqual(inventory["status"], "invalid_catalog")
+                self.assertEqual(inventory["resources"], [])
+                self.assertEqual(discovery.declared_configs(), ())
+
+    def test_catalog_environment_snapshot_is_nonsecret_and_does_not_read_provider_keys(self):
+        raw_catalog = json.dumps([
+            {
+                "provider_kind": "openai",
+                "model": "remote-model-a",
+                "endpoint": "https://api.openai.com/v1/responses",
+                "credential_alias": "openai-a",
+            }
+        ])
+        touched = []
+
+        def fake_getenv(name, default=""):
+            touched.append(name)
+            if name == "OPENAI_API_KEY":
+                raise AssertionError("secret key must not be inspected")
+            return raw_catalog if name == "GROX_REASONER_CATALOG_JSON" else default
+
+        with patch("grox.cognition_discovery.os.getenv", side_effect=fake_getenv):
+            snapshot = nonsecret_reasoner_config_from_env()
+
+        self.assertEqual(snapshot, {"GROX_REASONER_CATALOG_JSON": raw_catalog})
+        self.assertIn("GROX_REASONER_CATALOG_JSON", touched)
+        self.assertNotIn("OPENAI_API_KEY", touched)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_configured_cognition_discovery.py
+++ b/tests/unit/test_configured_cognition_discovery.py
@@ -101,6 +101,21 @@ class ConfiguredCognitionDiscoveryTests(unittest.TestCase):
         self.assertNotIn("PRIVATE-SENTINEL", encoded)
         self.assertNotIn("OPENAI_API_KEY", encoded)
 
+    def test_malformed_legacy_alias_does_not_change_base_discovery_contract(self):
+        config = {
+            "GROX_REASONER_PROVIDER": "openai",
+            "GROX_REASONER_MODEL": "legacy-model",
+            "GROX_REASONER_ENDPOINT": "https://api.openai.com/v1/responses",
+            "GROX_REASONER_CREDENTIAL_ALIAS": "not valid alias",
+        }
+
+        inventory = ConfiguredCognitionDiscovery(config).inventory()
+
+        self.assertEqual(inventory["status"], "ok")
+        self.assertEqual(inventory["configuration_source"], "legacy_single")
+        self.assertEqual(inventory["resources"][0]["model"], "legacy-model")
+        self.assertNotIn("credential_alias", inventory["resources"][0])
+
     def test_explicit_catalog_discovers_multiple_resources_in_declared_order_without_alias_exposure(self):
         catalog = [
             {


### PR DESCRIPTION
Closes #199
Parent: #115

Development-first runtime slice from canonical `main@62a27744dd9440f5ff1c4c8574a22ba44b90b1fa`.

Boundary:
- adds explicit `GROX_REASONER_CATALOG_JSON` for up to eight repository-supported cognition declarations;
- preserves legacy single-resource `GROX_REASONER_*` discovery behavior;
- catalog and legacy identity variables are mutually exclusive and fail closed if mixed;
- catalog entries contain only non-secret provider/model/endpoint/credential-alias metadata;
- public discovery omits credential aliases;
- malformed JSON, wrong shape, unknown fields, unsupported/incomplete entries, local remote-metadata misuse, duplicate resource IDs, and over-limit catalogs produce zero partial resources;
- declaration order is preserved as operator policy order only;
- no secret inspection, network, process/port scanning, provider construction, model loading, cognition, readiness, qualification, selection, ranking, fallback, Mission creation, or authority change.

Initial scope: exactly three runtime/test files. Base CI must pass before mutation hardening.