### PR TITLE
Qualify catalog-wide configured cognition credential binding awareness

### DIFF
--- a/src/grox/configured_cognition_catalog_binding.py
+++ b/src/grox/configured_cognition_catalog_binding.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .cognition_discovery import ConfiguredCognitionDiscovery
+from .credential_binding import ConfiguredCredentialBinding
+
+
+class ConfiguredCognitionCatalogBindingError(RuntimeError):
+    """Catalog binding composition detected an internal identity inconsistency."""
+
+
+class ConfiguredCognitionCatalogBinding:
+    """Compose configured cognition discovery with per-resource credential binding.
+
+    This surface is non-secret and read-only. It never consults a SecretBroker,
+    checks alias availability, materializes credentials, constructs providers,
+    touches the network, invokes cognition, or changes selection/authority state.
+    """
+
+    schema = "grox-configured-cognition-catalog-binding-v1"
+
+    def __init__(self, config: Mapping[str, Any]):
+        if not isinstance(config, Mapping):
+            raise TypeError("config must be a mapping")
+        self._config = dict(config)
+
+    @classmethod
+    def _base(
+        cls,
+        *,
+        status: str,
+        resources: list[dict[str, Any]],
+        configuration_source: str | None = None,
+    ) -> dict[str, Any]:
+        remote = [item for item in resources if item.get("provider_kind") == "openai"]
+        return {
+            "schema": cls.schema,
+            "status": status,
+            "configuration_source": configuration_source,
+            "resources": resources,
+            "remote_resource_count": len(remote),
+            "bound_remote_resource_count": sum(
+                item.get("credential_binding_configured") is True for item in remote
+            ),
+            "secret_broker_consulted": False,
+            "secret_alias_availability_checked": False,
+            "secret_materialized": False,
+            "credential_inspected": False,
+            "credential_validated": False,
+            "network_invoked": False,
+            "provider_constructed": False,
+            "cognition_invoked": False,
+            "ready": False,
+            "qualified_fit": False,
+            "selected": False,
+            "observed": False,
+            "routing_enabled": False,
+            "mission_created": False,
+            "authority_changed": False,
+            "auto_selection": False,
+        }
+
+    @staticmethod
+    def _base_item(resource: Mapping[str, Any], *, binding_status: str) -> dict[str, Any]:
+        return {
+            "resource_id": resource["resource_id"],
+            "resource_type": "configured_cognition_catalog_credential_binding",
+            "provider_kind": resource["provider_kind"],
+            "model": resource["model"],
+            "endpoint": resource["endpoint"],
+            "credential_binding_status": binding_status,
+            "credential_binding_configured": False,
+            "discovered": True,
+            "authorized": False,
+            "ready": False,
+            "qualified_fit": False,
+            "selected": False,
+            "observed": False,
+            "secret_broker_consulted": False,
+            "secret_alias_availability_checked": False,
+            "credential_inspected": False,
+            "credential_validated": False,
+            "network_invoked": False,
+            "provider_constructed": False,
+            "cognition_invoked": False,
+            "mission_created": False,
+            "authority_changed": False,
+            "auto_selection": False,
+        }
+
+    @staticmethod
+    def _binding_matches_resource(
+        binding: Mapping[str, Any],
+        resource: Mapping[str, Any],
+    ) -> bool:
+        return (
+            binding.get("resource_id") == resource.get("resource_id")
+            and binding.get("provider_kind") == resource.get("provider_kind")
+            and binding.get("model") == resource.get("model")
+            and binding.get("endpoint") == resource.get("endpoint")
+        )
+
+    def inventory(self) -> dict[str, Any]:
+        discovery = ConfiguredCognitionDiscovery(self._config)
+        discovered = discovery.inventory()
+        resources = discovered.get("resources") or []
+        if discovered.get("status") != "ok":
+            return self._base(
+                status=str(discovered.get("status") or "unconfigured"),
+                resources=[],
+                configuration_source=discovered.get("configuration_source"),
+            )
+
+        declarations = discovery.declared_configs()
+        if len(declarations) != len(resources):
+            raise ConfiguredCognitionCatalogBindingError(
+                "configured cognition catalog declaration/resource cardinality mismatch"
+            )
+
+        composed: list[dict[str, Any]] = []
+        remote_incomplete = False
+        for resource, declaration in zip(resources, declarations, strict=True):
+            provider_kind = resource.get("provider_kind")
+            if provider_kind != "openai":
+                composed.append(self._base_item(resource, binding_status="not_applicable"))
+                continue
+
+            binding_inventory = ConfiguredCredentialBinding(declaration).inventory()
+            bound_resources = binding_inventory.get("resources") or []
+            if binding_inventory.get("status") != "ok" or len(bound_resources) != 1:
+                remote_incomplete = True
+                composed.append(self._base_item(resource, binding_status="unbound"))
+                continue
+
+            bound = bound_resources[0]
+            if not self._binding_matches_resource(bound, resource):
+                raise ConfiguredCognitionCatalogBindingError(
+                    "configured credential binding identity differs from catalog resource"
+                )
+            alias = bound.get("credential_alias")
+            if not isinstance(alias, str) or not alias:
+                raise ConfiguredCognitionCatalogBindingError(
+                    "configured credential binding lacks an exact alias"
+                )
+
+            item = self._base_item(resource, binding_status="ok")
+            item["credential_alias"] = alias
+            item["credential_binding_configured"] = True
+            composed.append(item)
+
+        remote_count = sum(item.get("provider_kind") == "openai" for item in composed)
+        if remote_count == 0:
+            status = "not_applicable"
+        elif remote_incomplete:
+            status = "incomplete_binding"
+        else:
+            status = "ok"
+        return self._base(
+            status=status,
+            resources=composed,
+            configuration_source=discovered.get("configuration_source"),
+        )

--- a/src/grox/pilot.py
+++ b/src/grox/pilot.py
@@ -25,6 +25,7 @@ from .cognition_discovery import ConfiguredCognitionDiscovery, nonsecret_reasone
 from .configured_connection_awareness import ConfiguredConnectionPolicyAwareness
 from .configured_local_readiness import ConfiguredLocalCognitionReadiness
 from .credential_binding import ConfiguredCredentialBinding
+from .configured_cognition_catalog_binding import ConfiguredCognitionCatalogBinding
 from .graph import MissionGraphPlan
 from .graph.runtime import GraphExecutionError, MissionGraphRunner
 from .intelligence import LivingCompanyIntelligence
@@ -127,6 +128,10 @@ class PilotGorXu:
     def live_configured_credential_binding_inventory(self)->dict[str,Any]:
         """Report explicit non-secret credential-alias binding without broker or provider activity."""
         return ConfiguredCredentialBinding(nonsecret_reasoner_config_from_env()).inventory()
+
+    def live_configured_cognition_catalog_binding_inventory(self)->dict[str,Any]:
+        """Report per-resource non-secret credential binding across configured cognition catalog."""
+        return ConfiguredCognitionCatalogBinding(nonsecret_reasoner_config_from_env()).inventory()
 
     def live_configured_connection_policy_inventory(self, *, order:MissionOrder|None=None)->dict[str,Any]:
         """Report configured remote connection policy state without network or provider activity."""

--- a/tests/integration/test_configured_cognition_catalog_binding.py
+++ b/tests/integration/test_configured_cognition_catalog_binding.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from grox.pilot import PilotGorXu
+from grox.tools.secrets import SecretBroker
+
+
+ENDPOINT = "https://api.openai.com/v1/responses"
+
+
+class PilotConfiguredCognitionCatalogBindingTests(unittest.TestCase):
+    def test_pilot_catalog_binding_inventory_is_read_only_and_secret_blind(self):
+        with tempfile.TemporaryDirectory() as td:
+            pilot = PilotGorXu(Path(td), reasoner=object())
+            raw = json.dumps([
+                {
+                    "provider_kind": "openai",
+                    "model": "model-a",
+                    "endpoint": ENDPOINT,
+                    "credential_alias": "alias-a",
+                },
+                {
+                    "provider_kind": "local-llama-cpp",
+                    "model": "local-b",
+                },
+                {
+                    "provider_kind": "openai",
+                    "model": "model-c",
+                    "endpoint": ENDPOINT,
+                },
+            ])
+
+            with patch.dict(
+                "os.environ",
+                {"GROX_REASONER_CATALOG_JSON": raw},
+                clear=True,
+            ), patch.object(
+                SecretBroker,
+                "materialize_env",
+                side_effect=AssertionError("catalog binding must never materialize a secret"),
+            ):
+                result = pilot.live_configured_cognition_catalog_binding_inventory()
+
+            self.assertEqual(result["status"], "incomplete_binding")
+            self.assertEqual(
+                [item["model"] for item in result["resources"]],
+                ["model-a", "local-b", "model-c"],
+            )
+            self.assertEqual(result["remote_resource_count"], 2)
+            self.assertEqual(result["bound_remote_resource_count"], 1)
+            self.assertEqual(result["resources"][0]["credential_alias"], "alias-a")
+            self.assertEqual(result["resources"][1]["credential_binding_status"], "not_applicable")
+            self.assertEqual(result["resources"][2]["credential_binding_status"], "unbound")
+            self.assertFalse(result["secret_broker_consulted"])
+            self.assertFalse(result["secret_alias_availability_checked"])
+            self.assertFalse(result["credential_inspected"])
+            self.assertFalse(result["network_invoked"])
+            self.assertFalse(result["provider_constructed"])
+            self.assertFalse(result["cognition_invoked"])
+            self.assertFalse(result["ready"])
+            self.assertFalse(result["selected"])
+            self.assertFalse(result["routing_enabled"])
+            self.assertFalse(result["authority_changed"])
+            self.assertEqual(pilot.store.recent_missions(), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/mutation/run_critical_invariants.py
+++ b/tests/mutation/run_critical_invariants.py
@@ -352,6 +352,14 @@ SPECS: tuple[MutationSpec, ...] = (
         nodeid="tests/unit/test_configured_cognition_discovery.py::ConfiguredCognitionDiscoveryTests::test_catalog_malformed_unsupported_duplicate_and_over_limit_fail_closed_without_partial_inventory",
     ),
     MutationSpec(
+        name="configured-cognition-catalog-binding-exact-resource-identity",
+        invariant="Catalog-wide configured cognition credential binding must preserve the exact discovered resource identity.",
+        path="src/grox/configured_cognition_catalog_binding.py",
+        old='            if not self._binding_matches_resource(bound, resource):\n',
+        new='            if False and not self._binding_matches_resource(bound, resource):\n',
+        nodeid="tests/unit/test_configured_cognition_catalog_binding.py::ConfiguredCognitionCatalogBindingTests::test_binding_identity_mismatch_fails_closed",
+    ),
+    MutationSpec(
         name="ci-action-immutable-pin",
         invariant="Third-party GitHub Actions must remain pinned to immutable full commit SHAs.",
         path=".github/workflows/ci.yml",

--- a/tests/unit/test_configured_cognition_catalog_binding.py
+++ b/tests/unit/test_configured_cognition_catalog_binding.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import json
+import unittest
+from unittest.mock import patch
+
+from grox.configured_cognition_catalog_binding import (
+    ConfiguredCognitionCatalogBinding,
+    ConfiguredCognitionCatalogBindingError,
+)
+from grox.credential_binding import ConfiguredCredentialBinding
+
+
+ENDPOINT = "https://api.openai.com/v1/responses"
+
+
+class ConfiguredCognitionCatalogBindingTests(unittest.TestCase):
+    @staticmethod
+    def _catalog(entries):
+        return {"GROX_REASONER_CATALOG_JSON": json.dumps(entries)}
+
+    def test_mixed_catalog_preserves_order_and_exact_remote_alias_binding(self):
+        result = ConfiguredCognitionCatalogBinding(
+            self._catalog([
+                {
+                    "provider_kind": "openai",
+                    "model": "model-a",
+                    "endpoint": ENDPOINT,
+                    "credential_alias": "alias-a",
+                },
+                {
+                    "provider_kind": "local-llama-cpp",
+                    "model": "local-b",
+                },
+                {
+                    "provider_kind": "openai",
+                    "model": "model-c",
+                    "endpoint": ENDPOINT,
+                    "credential_alias": "alias-c",
+                },
+            ])
+        ).inventory()
+
+        self.assertEqual(result["status"], "ok")
+        self.assertEqual(result["configuration_source"], "explicit_catalog")
+        self.assertEqual(result["remote_resource_count"], 2)
+        self.assertEqual(result["bound_remote_resource_count"], 2)
+        self.assertEqual(
+            [item["model"] for item in result["resources"]],
+            ["model-a", "local-b", "model-c"],
+        )
+        self.assertEqual(result["resources"][0]["credential_alias"], "alias-a")
+        self.assertEqual(result["resources"][0]["credential_binding_status"], "ok")
+        self.assertTrue(result["resources"][0]["credential_binding_configured"])
+        self.assertEqual(result["resources"][1]["credential_binding_status"], "not_applicable")
+        self.assertNotIn("credential_alias", result["resources"][1])
+        self.assertEqual(result["resources"][2]["credential_alias"], "alias-c")
+        for item in result["resources"]:
+            self.assertFalse(item["authorized"])
+            self.assertFalse(item["ready"])
+            self.assertFalse(item["qualified_fit"])
+            self.assertFalse(item["selected"])
+            self.assertFalse(item["observed"])
+        self.assertFalse(result["secret_broker_consulted"])
+        self.assertFalse(result["secret_alias_availability_checked"])
+        self.assertFalse(result["network_invoked"])
+        self.assertFalse(result["provider_constructed"])
+        self.assertFalse(result["cognition_invoked"])
+        self.assertFalse(result["routing_enabled"])
+        self.assertFalse(result["authority_changed"])
+
+    def test_missing_remote_alias_is_retained_as_unbound_instead_of_disappearing(self):
+        result = ConfiguredCognitionCatalogBinding(
+            self._catalog([
+                {
+                    "provider_kind": "openai",
+                    "model": "model-a",
+                    "endpoint": ENDPOINT,
+                    "credential_alias": "alias-a",
+                },
+                {
+                    "provider_kind": "openai",
+                    "model": "model-b",
+                    "endpoint": ENDPOINT,
+                },
+            ])
+        ).inventory()
+
+        self.assertEqual(result["status"], "incomplete_binding")
+        self.assertEqual(result["remote_resource_count"], 2)
+        self.assertEqual(result["bound_remote_resource_count"], 1)
+        self.assertEqual(len(result["resources"]), 2)
+        self.assertEqual(result["resources"][1]["model"], "model-b")
+        self.assertEqual(result["resources"][1]["credential_binding_status"], "unbound")
+        self.assertFalse(result["resources"][1]["credential_binding_configured"])
+        self.assertNotIn("credential_alias", result["resources"][1])
+
+    def test_malformed_catalog_propagates_fail_closed_without_partial_bindings(self):
+        result = ConfiguredCognitionCatalogBinding(
+            {"GROX_REASONER_CATALOG_JSON": "{not-json"}
+        ).inventory()
+
+        self.assertEqual(result["status"], "invalid_catalog")
+        self.assertEqual(result["resources"], [])
+        self.assertEqual(result["remote_resource_count"], 0)
+        self.assertEqual(result["bound_remote_resource_count"], 0)
+
+    def test_legacy_single_resource_remains_supported_without_changing_legacy_binder(self):
+        config = {
+            "GROX_REASONER_PROVIDER": "openai",
+            "GROX_REASONER_MODEL": "legacy-model",
+            "GROX_REASONER_ENDPOINT": ENDPOINT,
+            "GROX_REASONER_CREDENTIAL_ALIAS": "legacy-alias",
+        }
+
+        catalog = ConfiguredCognitionCatalogBinding(config).inventory()
+        legacy = ConfiguredCredentialBinding(config).inventory()
+
+        self.assertEqual(catalog["status"], "ok")
+        self.assertEqual(catalog["configuration_source"], "legacy_single")
+        self.assertEqual(catalog["resources"][0]["resource_id"], legacy["resources"][0]["resource_id"])
+        self.assertEqual(catalog["resources"][0]["credential_alias"], "legacy-alias")
+
+    def test_binding_identity_mismatch_fails_closed(self):
+        config = self._catalog([
+            {
+                "provider_kind": "openai",
+                "model": "model-a",
+                "endpoint": ENDPOINT,
+                "credential_alias": "alias-a",
+            }
+        ])
+        forged = {
+            "status": "ok",
+            "resources": [{
+                "resource_id": "cognition:configured:openai:forged",
+                "provider_kind": "openai",
+                "model": "model-a",
+                "endpoint": ENDPOINT,
+                "credential_alias": "alias-a",
+            }],
+        }
+
+        with patch.object(ConfiguredCredentialBinding, "inventory", return_value=forged):
+            with self.assertRaisesRegex(ConfiguredCognitionCatalogBindingError, "identity differs"):
+                ConfiguredCognitionCatalogBinding(config).inventory()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #201
Parent: #115

Development-first runtime slice from canonical `main@6095d2c3267ce48c194b90b0e20050d0b6d5de28`.

Boundary:
- composes normalized configured cognition declarations with the existing single-resource credential-binding contract;
- preserves catalog declaration order and exact resource/provider/model/endpoint identity;
- remote OpenAI entries report exact configured alias metadata when present;
- missing remote aliases remain visible as unbound resources;
- local llama.cpp entries remain binding-not-applicable;
- malformed/ambiguous catalog discovery propagates fail-closed with no partial bindings;
- legacy single-resource binder is unchanged and remains available;
- no SecretBroker consultation, alias availability checks, secret materialization/inspection, network, provider construction, cognition, readiness, qualification, selection, routing, Mission creation, or authority change.

Initial scope: exactly four runtime/test files. Base CI must pass before mutation hardening.